### PR TITLE
feat: driver for Attocube ANC300

### DIFF
--- a/docs/examples/Attocube_ANC300.ipynb
+++ b/docs/examples/Attocube_ANC300.ipynb
@@ -5,8 +5,7 @@
    "metadata": {},
    "source": [
     "# QCoDeS example with Attocube ANC300\n",
-    "## The controller is equiped with two ANM150 axis modules\n",
-    "The driver is not developed for the automatic detection of modules because it could not be tested."
+    "## The test controller is equiped with two ANM150 axis modules"
    ]
   },
   {
@@ -31,14 +30,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ANC = ANC300( name='ANC300', address='COM7' )"
+    "ANC = ANC300( name='ANC300', address='ASRL7' )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are up to 7 axis available (axis1 .. axis7)"
+    "There are up to 7 axis available (axis1 .. axis7). At startup all axis are scanned. If there is no axis installed, the submodule with the specific name will not be created."
    ]
   },
   {

--- a/docs/examples/Attocube_ANC300.ipynb
+++ b/docs/examples/Attocube_ANC300.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# QCoDeS example with Attocube ANC300\n",
+    "## The controller is equiped with two ANM150 axis modules\n",
+    "The driver is not developed for the automatic detection of modules because it could not be tested."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qcodes.instrument_drivers.attocube.ANC300 import ANC300"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the USB-Port and change it accordingly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ANC = ANC300( name='ANC300', address='COM7' )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are up to 7 axis available (axis1 .. axis7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "axis1 = ANC.submodules['axis1']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read and change the current frequency setting for this axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FREQ  210\n"
+     ]
+    }
+   ],
+   "source": [
+    "print( \"FREQ \", axis1.frequency()   )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FREQ  200\n"
+     ]
+    }
+   ],
+   "source": [
+    "axis1.frequency(200)\n",
+    "print( \"FREQ \", axis1.frequency()   )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The movement runs asynchronosly, there is no function to get the current position"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "axis1.mode( 'stp' )\n",
+    "axis1.amplitude( 20 )\n",
+    "axis1.move( 2000 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wait until the axis stops (after the number of steps or after the 'stopMove()' command)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "axis1.waitMove()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Close the connection to the device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ANC.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  },
+  "nbsphinx": {
+   "execute": "never"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
@@ -1,0 +1,460 @@
+# -*- coding: utf-8 -*-
+"""
+File:    ANC300.py
+Date:    Jan 2020
+Author:  Michael Wagener, FZJ / ZEA-2, m.wagener@fz-juelich.de
+Purpose: Main instrument driver for the Attocube ANC300 controller
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! This driver code is written for our instrument, the ANC300 with two !!!
+!!! ANM150 modules. Therefore this code contains no functions to        !!!
+!!! automatically distinguish between the modules.                      !!!
+!!! In the comments the axis types are noted and the code not suitable  !!!
+!!! for the ANM150 is commented out.                                    !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+PyLint rating: Your code has been rated at 9.06/10
+
+"""
+
+
+import serial
+
+from qcodes.instrument.base import Instrument
+from qcodes.instrument.channel import InstrumentChannel, ChannelList
+from qcodes import validators as vals
+
+# if set to True, every communication line is printed
+_USE_DEBUG = False
+
+# if set to True, the simulation in ANC300sim.py is used and no real device
+_USE_SIMULATION = False
+
+
+
+
+class Anc300Axis(InstrumentChannel):
+    """
+    The Attocube ANC300 piezo controller has up to 7 axis.
+    Parameters:
+        frequency: Set the frequency of the output signal. The maximum is
+            restricted by the combination of output voltage and
+            Capacitance of the piezo actuators.
+        amplitude: Set the maximum level of the output signal.
+        offset: Add a constant voltage to the output signal.
+            Attention: the output level is only from 0 to 150 V.
+        filter: Set the filter frequency of the internal low pass filter.
+        mode: Setting to a certain mode typically switches other functionalities
+            off. Especially, there are the following modes:
+                'gnd': Setting to this mode diables all outputs and
+                       connects them to chassis mass.
+                'inp': In this mode, AC-IN and DC-IN can be enabled
+                       using the setaci and setdci commands. Setting
+                       to inp mode disables stepping and offset modes.
+                'cap': Setting to cap mode starts a capacitance measurement.
+                       The axis returns to gnd mode afterwards. It is not
+                       needed to switch to gnd mode before.
+                'stp': This enables stepping mode. AC-IN and DC-IN
+                       functionalities are not modified, while an offset
+                       function would be turned off.
+                'off': This enables offset mode. AC-IN and DC-IN
+                       functionalities are not modified, while any
+                       stepping would be turned off.
+                'stp+': This enables additive offset + stepping mode.
+                        Stepping waveforms are added to an offset.
+                        AC-IN and DC-IN functionalities are not modified.
+                'stp-': This enables subtractive offset + stepping mode.
+                        Stepping waveforms are subtracted from an offset.
+                        AC-IN and DC-IN functionalities, are not modified.
+        ac: When switching on the AC-IN feature, a voltage of up to 10 VAC
+            can be added to the output (gain 1, no amplification) using
+            the AC-IN BNC on the frontplate of the module.
+        dc: When switching on the DC-IN feature, a voltage in the range
+            -10 .. +10 V can be added to the output. The gain is 15.
+        move: Start the movement with the given steps. For moving out
+              use positive numbers and to move in use negative numbers.
+        start: Start a continous movement in the given direction.
+        triggerUp: Set/get input trigger up number on axis
+        triggerDown: Set/get input trigger down number on axis
+    """
+    def __init__(self, parent: 'ANC300', name: str, axis: int) -> None:
+        """
+        Creates a new Anc300Axis class instance
+        Args:
+            parent: the internal QCoDeS name of the instrument this axis belongs to
+            name: the internal QCoDeS name of the axis itself
+            axis: the Index of the axis
+        """
+        super().__init__(parent, name)
+        self._axisnr = axis
+        self.add_parameter('frequency',
+                           label='Set/get the stepping frequency',
+                           get_cmd='getf {}'.format(axis),
+                           set_cmd='setf {}'.format(axis)+' {}',
+                           vals=vals.Ints(1, 10000),
+                           unit='Hz',
+                           docstring="""
+                           Set the frequency of the output signal. The maximum is
+                           restricted by the combination of output voltage and
+                           Capacitance of the piezo actuators.
+                           """
+                           )
+        self.add_parameter('amplitude',
+                           label='Set/get the stepping amplitude',
+                           get_cmd='getv {}'.format(axis),
+                           set_cmd='setv {}'.format(axis)+' {}',
+                           vals=vals.Numbers(0.0, 150.0),
+                           unit='V',
+                           docstring="Set the maximum level of the output signal."
+                           )
+        self.add_parameter('offset',
+                           label='Set/get the offset voltage',
+                           get_cmd='geta {}'.format(axis),
+                           set_cmd='seta {}'.format(axis)+' {}',
+                           vals=vals.Numbers(0.0, 150.0),
+                           unit='V',
+                           docstring="""
+                           Add a constant voltage to the output signal.
+                           Attention: the output level is only from 0 to 150 V.
+                           """
+                           )
+        # this is not for ANM150
+        #self.add_parameter('filter',
+        #                   label='Set/get filter setting',
+        #                   get_cmd='getfil {}'.format(axis),
+        #                   set_cmd='setfil {}'.format(axis)+' {}',
+        #                   vals=vals.Enum('off', '16', '160'),
+        #                   unit='Hz',
+        #                   docstring="Set the filter frequency of the internal low pass filter."
+        #                   )
+        self.add_parameter('mode',
+                           label='Set/get mode',
+                           get_cmd='getm {}'.format(axis),
+                           set_cmd='setm {}'.format(axis)+' {}',
+                           #vals=vals.Enum(...'inp'...) not for ANM150
+                           vals=vals.Enum('gnd', 'cap', 'stp', 'off', 'stp+', 'stp-'),
+                           docstring="""
+                           Setting to a certain mode typically switches other functionalities
+                           off. Especially, there are the following modes:
+                               'gnd': Setting to this mode diables all outputs and
+                                      connects them to chassis mass.
+                               'cap': Setting to cap mode starts a capacitance measurement.
+                                      The axis returns to gnd mode afterwards. It is not
+                                      needed to switch to gnd mode before.
+                               'stp': This enables stepping mode. AC-IN and DC-IN
+                                      functionalities are not modified, while an offset
+                                      function would be turned off.
+                               'off': This enables offset mode. AC-IN and DC-IN
+                                      functionalities are not modified, while any
+                                      stepping would be turned off.
+                               'stp+': This enables additive offset + stepping mode.
+                                       Stepping waveforms are added to an offset.
+                                       AC-IN and DC-IN functionalities are not modified.
+                               'stp-': This enables subtractive offset + stepping mode.
+                                       Stepping waveforms are subtracted from an offset.
+                                       AC-IN and DC-IN functionalities, are not modified.
+                            """
+                           # not for ANM150:
+                           #'inp': In this mode, AC-IN and DC-IN can be enabled
+                           #       using the setaci and setdci commands. Setting
+                           #       to inp mode disables stepping and offset modes.
+                           )
+        self.add_parameter('ac',
+                           label='Set/get status of AC-IN input',
+                           get_cmd='getaci {}'.format(axis),
+                           set_cmd='setaci {}'.format(axis)+' {}',
+                           vals=vals.Enum('off', 'on'),
+                           docstring="""
+                           When switching on the AC-IN feature, a voltage of up to 10 VAC
+                           can be added to the output (gain 1, no amplification) using
+                           the AC-IN BNC on the frontplate of the module.
+                           """
+                           )
+        self.add_parameter('dc',
+                           label='Set/get status of DC-IN input',
+                           get_cmd='getdci {}'.format(axis),
+                           set_cmd='setdci {}'.format(axis)+' {}',
+                           vals=vals.Enum('off', 'on'),
+                           docstring="""
+                           When switching on the DC-IN feature, a voltage in the range
+                           -10 .. +10 V can be added to the output. The gain is 15.
+                           """
+                           )
+        self.add_parameter('move',
+                           label='Move steps',
+                           get_cmd=False,
+                           set_cmd=self._domove,
+                           vals=vals.Ints(),
+                           docstring="""
+                           Start the movement with the given steps. For moving out
+                           use positive numbers and to move in use negative numbers.
+                           """
+                           )
+        self.add_parameter('start',
+                           label='Move continously',
+                           get_cmd=False,
+                           set_cmd=self._contmove,
+                           vals=vals.Enum('up', 'down'),
+                           docstring="Start a continous movement in the given direction."
+                           )
+        self.add_parameter('triggerUp',
+                           label='Set/get input trigger up number on axis',
+                           get_cmd='gettu {}'.format(axis),
+                           set_cmd='settu {}'.format(axis)+' {}',
+                           vals=vals.Enum('off', '1', '2', '3', '4', '5', '6', '7'),
+                           docstring="Set/get input trigger up number on axis"
+                           )
+        self.add_parameter('triggerDown',
+                           label='Set/get input trigger down numbers on axis',
+                           get_cmd='gettd {}'.format(axis),
+                           set_cmd='settd {}'.format(axis)+' {}',
+                           vals=vals.Enum('off', '1', '2', '3', '4', '5', '6', '7'),
+                           docstring="Set/get input trigger down number on axis"
+                           )
+
+    def _domove(self, value: int):
+        """
+        Internal helper function to start the movement.
+        Parameter:
+            value - the amount of steps to move, the sign denotes the direction
+        """
+        if value < 0:
+            self._parent.write('stepd {} {}'.format(self._axisnr, -value))
+        elif value > 0:
+            self._parent.write('stepu {} {}'.format(self._axisnr, value))
+        else:
+            raise RuntimeError("zero is an invalid move parameter")
+
+    def _contmove(self, direc: str):
+        """
+        Internal helper function to start the continous movement.
+        Parameter:
+            direc - the direction 'up' or 'down'
+        """
+        if direc == 'up':
+            self._parent.write('stepu {} c'.format(self._axisnr))
+        elif direc == 'down':
+            self._parent.write('stepd {} c'.format(self._axisnr))
+
+    def waitMove(self):
+        """
+        Global function to wait until the movement is finished.
+        """
+        self._parent.write('stepw {}'.format(self._axisnr))
+
+    def stopMove(self):
+        """
+        Global function to stop the movement.
+        """
+        self._parent.write('stop {}'.format(self._axisnr))
+
+
+
+class Anc300TriggerOut(InstrumentChannel):
+    """
+    The Attocube ANC300 piezo controller has three trigger outputs.
+    Parameters:
+        state: Set / get the state of the output
+    NOT FOR THE CURRENT TEST DEVICE!
+    """
+    def __init__(self, parent: 'ANC300', name: str, num: int) -> None:
+        """
+        Creates a new TriggerOut Signal
+        Args:
+            parent: the internal QCoDeS name of the instrument this output belongs to
+            name: the internal QCoDeS name of the output itself
+            num: the Index of the trigger output
+        """
+        super().__init__(parent, name)
+        self.add_parameter('state',
+                           label='Set/get trigger output level',
+                           get_cmd='getto {}'.format(num),
+                           set_cmd='setto {}'.format(num)+' {}',
+                           val_mapping={'off': 0, 'on': 1},
+                           vals=vals.Enum('off', 'on'),
+                           docstring="Sets the trigger output signal"
+                           )
+
+
+
+class ANC300(Instrument):
+    """
+    This is the qcodes driver for the Attocube ANC300.
+
+    Status:
+        coding: finished
+        communication tests: done
+        usage in experiment: not yet
+    """
+
+    def __init__(self, name, address, **kwargs):
+        super().__init__(name, **kwargs)
+
+        if _USE_SIMULATION:
+            # The simulation class has the same functions as the serial.Serial():
+            #   write() / readline() / close()
+            from qcodes.instrument_drivers.attocube.ANC300sim import MockComHandle
+            self._comport = MockComHandle()
+        else:
+            # initialization of serial port
+            self._comport = serial.Serial()
+            self._comport.port = address
+            self._comport.timeout = 2
+            try:
+                self._comport.open()
+            except:
+                # make a second try to open the port. If this fails then report it
+                self._comport.close()
+                self._comport.open()
+            self._comport.flushInput()
+            self._comport.flushOutput()
+
+        # for security check the ID from the device
+        self.idn = self.ask("ver")
+        if _USE_DEBUG:
+            print("DBG:", self.idn)
+        if not self.idn[0].startswith("attocube ANC300"):
+            raise RuntimeError("Invalid device ID found: "+str(self.idn))
+
+        # instantiate the axis channels
+        axischannels = ChannelList(self, "Anc300Channels", Anc300Axis,
+                                   snapshotable=False)
+        for ax in range(1, 7+1):
+            name = 'axis{}'.format(ax)
+            axischan = Anc300Axis(self, name, ax)
+            axischannels.append(axischan)
+            self.add_submodule(name, axischan)
+        axischannels.lock()
+        self.add_submodule('axis_channels', axischannels)
+
+        # instantiate the trigger channels
+        triggerchannels = ChannelList(self, "Anc300Trigger", Anc300TriggerOut,
+                                      snapshotable=False)
+        for ax in [1, 2, 3]:
+            name = 'trigger{}'.format(ax)
+            trigchan = Anc300TriggerOut(self, name, ax)
+            triggerchannels.append(trigchan)
+            self.add_submodule(name, trigchan)
+        triggerchannels.lock()
+        self.add_submodule('trigger_channels', triggerchannels)
+
+
+    def _write(self, cmd: str):
+        """
+        Central routine for a simple write and read the answers until the device
+        sends an "OK" or "ERROR".
+        """
+        # all lines have to end with a CR / LF
+        setstr = cmd + '\r\n'
+        # the device can not handle unicode strings
+        self._comport.write(setstr.encode('ascii'))
+        # first, the device echos what was written
+        rv = self._comport.readline().decode('ascii')
+        if _USE_DEBUG:
+            print("DBG write-echo:" + rv)
+        # then we collect the output lines until an OK or ERROR comes
+        output = []
+        while True:
+            rv = self._comport.readline().decode('ascii').rstrip()
+            if _USE_DEBUG:
+                print("DBG write-answ:" + rv)
+            if rv.startswith('OK'):
+                # positive answer returns all answer lines
+                return output
+            if rv.startswith('ERROR'):
+                # negative answer raises an exception
+                raise RuntimeError(output[-1])
+            if output != "":
+                # the output array contains all lines read from the device
+                output.append(rv)
+
+
+    def write_raw(self, cmd: str) -> None:
+        """
+        Central routine to send a value to the device
+        """
+        self._write(cmd)
+
+
+    def ask_raw(self, cmd: str) -> str:
+        """
+        Central routine for a query (write and read).
+        """
+        output = self._write(cmd)
+        # The output array contains all lines read from the device. If the
+        # version information is read, it consists of two lines. The normal
+        # answers have only one line.
+        outval = output[-1].split(' = ')
+        # The normal output format for values is <parameter> = <value> <unit>
+        if len(outval) == 2:
+            if _USE_DEBUG:
+                print("DBG ask:" + outval[1].split()[0])
+            return outval[1].split()[0] # return only the value without the unit
+        # returns the complete output (for version information)
+        return output
+
+
+    def stopall(self):
+        """
+        Routine to stop all axis, regardless if the axis is available
+        """
+        if _USE_DEBUG:
+            print("Stop all axis")
+        for a in range(7):
+            self._write('stop {}'.format(a+1))
+
+
+    def close(self):
+        """
+        Override of the base class' close function
+        """
+        self._comport.close()
+        super().close()
+
+
+    def version(self):
+        """
+        Read all possible version informations and returns them as a dict
+        """
+        retval = dict()
+        retval['Version'] = self.ask('ver')
+        retval['ContrSN'] = self.ask('getcser')
+        for i in range(7):
+            try:
+                retval['SN{}'.format(i+1)] = self.ask('getser {}'.format(i+1))
+            except:
+                # if the axis module is not installed ...
+                retval['SN{}'.format(i+1)] = 'EMPTY'
+        return retval
+
+
+    def getall(self, submod="*"):
+        """
+        Read all parameters and retun them to the caller. This will scan all
+        submodules with all parameters, so in this function no changes are
+        necessary for new modules or parameters.
+        Args:
+            submod: (optional) returns only the parameters for this submodule
+        Output:
+            dict with all parameters, the key is the modulename and the parametername
+        """
+        retval = {}
+        if submod == "*":
+            # ID and options only if all modules are returned
+            retval.update({"ID": self.idn})
+
+        for m in self.submodules:
+            mod = self.submodules[m]
+            if not isinstance(mod, ChannelList) and (submod in ("*", m)):
+                for p in mod.parameters:
+                    par = mod.parameters[p]
+                    try:
+                        if par.unit:
+                            val = str(par()).strip() + " " + par.unit
+                        else:
+                            val = str(par()).strip()
+                    except:
+                        val = "** not readable **"
+                    retval.update({m + "." + p: val})
+
+        return retval

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
@@ -400,17 +400,17 @@ class ANC300(VisaInstrument):
         self.add_submodule('trigger_channels', triggerchannels)
 
 
-    def write_raw(self, cmd: str) -> str:
+    def write_raw(self, cmd: str) -> None:
         """Write cmd and wait until the 'OK' or 'ERROR' comes back from the device.
         
         Args:
             cmd: Command to write to controller.
 
         Returns:
-            Statusstring
+            None
 
         Raises:
-            RuntimeError if Error-Message from the device is read.
+            RuntimeError: if Error-Message from the device is read.
             VisaIOError: Timeout expired before operation completed.
         """
         status = super().ask_raw(cmd) # send the command to the device and read the echo/status
@@ -418,7 +418,7 @@ class ANC300(VisaInstrument):
             # now the device sends an echo
             status = self.visa_handle.read() # read the status line again
         if status.startswith('OK'):
-            return status
+            return
         if status.startswith('ERROR'):
             raise RuntimeError(status)
         # the line before the 'ERROR' a message will be send from the device
@@ -426,7 +426,7 @@ class ANC300(VisaInstrument):
         status = self.visa_handle.read() # read the last status line
         if status.startswith('ERROR'):
             raise RuntimeError(response)
-        return response
+        return
 
 
     def ask_raw(self, cmd: str) -> str:
@@ -439,7 +439,7 @@ class ANC300(VisaInstrument):
             Response of Attocube controller to the query.
 
         Raises:
-            RuntimeError if Error-Message from the device is read.
+            RuntimeError: if Error-Message from the device is read.
         """
         response = super().ask_raw(cmd) # send the command to the device and read the echo/status
         if response.startswith('> '): # sometimes the response starts with '> '. I don't know why.

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
@@ -353,7 +353,7 @@ class ANC300(Instrument):
         if _USE_DEBUG:
             print("DBG write-echo:" + rv)
         # then we collect the output lines until an OK or ERROR comes
-        output = []
+        output: List[str] = []
         while True:
             rv = self._comport.readline().decode('ascii').rstrip()
             if _USE_DEBUG:

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
@@ -17,7 +17,7 @@ PyLint rating: Your code has been rated at 9.06/10
 
 """
 
-
+from typing import List
 import serial
 
 from qcodes.instrument.base import Instrument

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300.py
@@ -411,7 +411,6 @@ class ANC300(VisaInstrument):
 
         Raises:
             RuntimeError: if Error-Message from the device is read.
-            VisaIOError: Timeout expired before operation completed.
         """
         status = super().ask_raw(cmd) # send the command to the device and read the echo/status
         if status == cmd:

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300sim.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300sim.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
-"""
-File:    ANC300sim.py
-Date:    Jan 2020
-Author:  Michael Wagener, FZJ / ZEA-2, m.wagener@fz-juelich.de
-Purpose: Simulation for the Attocube ANC300 driver in the same way as
-         it is used in our lab.
+"""QCoDeS- Simulation for the Attocube ANC300 controller.
+
+Simulation for the Attocube ANC300 driver in the same way as it is used in our lab.
+
+Author:
+    Michael Wagener, FZJ / ZEA-2, m.wagener@fz-juelich.de
 """
 
-#from unittest import TestCase
-#from unittest.mock import patch
 import pyvisa
 from qcodes.instrument.visa import VisaInstrument
-from qcodes.utils.validators import Numbers
-#import warnings
 
 # if set to True, every communication line is printed
 _USE_DEBUG = True
@@ -25,21 +21,16 @@ _USE_ECHO = True
 
 class MockVisa(VisaInstrument):
     def __init__(self, *args, **kwargs):
-        #print("DBG-Mock:", args, kwargs)
         super().__init__(*args, **kwargs)
-        ##self.add_parameter('state',
-        ##                   get_cmd='STAT?', get_parser=float,
-        ##                   set_cmd='STAT:{:.3f}',
-        ##                   vals=Numbers(-20, 20))
 
     def set_address(self, address):
         self.visa_handle = MockVisaHandle()
 
 
 class MockVisaHandle:
-    '''
+    """
     Simulate the API needed for the communication.
-    '''
+    """
     
     # List of possible commands asked the instrument to give a realistic answer.
     cmddef = {'ver': ['attocube ANC300 controller version 1.1.0-1304 2013-10-17 08:16',
@@ -150,29 +141,12 @@ class MockVisaHandle:
             print("DBG-Mock: close")
         self.closed = True
 
-##    @property
-##    def session(self):
-##        """Resource Manager session handle.
-##
-##        :raises: :class:`pyvisa.errors.InvalidSession` if session is closed.
-##        """
-##        return None # not used here
-
-##    def write(self, session, data):
     def write(self, data):
-        """Writes data to device or interface synchronously.
-
-        Corresponds to viWrite function of the VISA library.
-
-        :param session: Unique logical identifier to a session.
-        :param data: data to be written.
-        :type data: str
-        :return: Number of bytes actually transferred, return value of the library call.
-        :rtype: int, :class:`pyvisa.constants.StatusCode`
+        """
+        Writes data to device or interface synchronously.
         """
         if self.closed:
             raise RuntimeError("Trying to write to a closed instrument")
-        ##cmd = data.decode('ascii').rstrip()
         cmd = data.rstrip()
         if _USE_DEBUG:
             print("DBG-Mock: write", cmd)
@@ -197,7 +171,7 @@ class MockVisaHandle:
                 if len(unit) > 1:
                     unit = unit[1]
                 else:
-                    unit = "" # unit[0]
+                    unit = ""
                 setval = [ val[0]+' = '+tmp[2]+' '+unit ]
                 self.cmddef.update( {cmd: setval} )
             else:
@@ -215,104 +189,25 @@ class MockVisaHandle:
             self.answer.append('OK')
         return len(cmd), pyvisa.constants.StatusCode.success
 
-##    def read(self, session, count):
     def read(self):
-        """Reads data from device or interface synchronously.
-
-        Corresponds to viRead function of the VISA library.
-
-        :param session: Unique logical identifier to a session.
-        :param count: Number of bytes to be read.
-        :return: data read, return value of the library call.
-        :rtype: bytes, :class:`pyvisa.constants.StatusCode`
+        """
+        Reads data from device or interface synchronously.
         """
         if self.closed:
             raise RuntimeError("Trying to read from a closed instrument")
         if _USE_DEBUG:
             print("DBG-Mock: read", self.answer)
         if len(self.answer) > 0:
-            ##return self.answer.pop(0).encode('ascii'), pyvisa.constants.StatusCode.success
             return self.answer.pop(0)
-        ##return 'ERROR'.encode('ascii'), pyvisa.constants.StatusCode.error_io
         return 'ERROR'
 
     def ask(self, cmd):
         print("DBG-Mock: MockVisaHandle ask", cmd)
         if self.closed:
             raise RuntimeError("Trying to ask a closed instrument")
-        ##self.write(None, cmd)
-        ##return self.read(None, 100)
         self.write(cmd)
         return self.read()
 
     def query(self, cmd):
-        #print("DBG-Mock: MockVisaHandle query", cmd)
-        ##self.write(None, cmd)
-        ##return self.read(None, 100)
         self.write(cmd)
         return self.read()
-
-
-
-    # Damit AttocubeController.py auch funktioniert....
-
-    def _write(self, cmd: str):
-        """
-        Central routine for a simple write and read the answers until the device
-        sends an "OK" or "ERROR".
-        """
-        ##sess = self.visa_handle.session
-        # all lines have to end with a CR / LF
-        setstr = cmd + '\r\n'
-        # the device can not handle unicode strings
-        ##cnt, sta = self.visa_handle.write(sess, setstr.encode('ascii') )
-        self.write(setstr)
-        # first, the device echos what was written
-        ##rv, sta = self.visa_handle.read(sess, 1000) # .decode('ascii')
-        rv = self.read()
-        rv = rv.rstrip()
-        if _USE_DEBUG:
-            print("DBG write-echo:", rv)
-        # then we collect the output lines until an OK or ERROR comes
-        output = []
-        while True:
-            ##rv, sta = self.visa_handle.read(sess, 1000)
-            rv = self.read()
-            ##rv = rv.decode('ascii').rstrip()
-            rv = rv.rstrip()
-            if _USE_DEBUG:
-                print("DBG write-answ:", rv)
-            if rv.startswith('OK'):
-                # positive answer returns all answer lines
-                return output
-            if rv.startswith('ERROR'):
-                # negative answer raises an exception
-                raise RuntimeError(output[-1])
-            if output != "":
-                # the output array contains all lines read from the device
-                output.append(rv)
-
-
-    def write_raw(self, cmd: str) -> None:
-        """
-        Central routine to send a value to the device
-        """
-        self._write(cmd)
-
-
-    def ask_raw(self, cmd: str) -> str:
-        """
-        Central routine for a query (write and read).
-        """
-        output = self._write(cmd)
-        # The output array contains all lines read from the device. If the
-        # version information is read, it consists of two lines. The normal
-        # answers have only one line.
-        outval = output[-1].split(' = ')
-        # The normal output format for values is <parameter> = <value> <unit>
-        if len(outval) == 2:
-            if _USE_DEBUG:
-                print("DBG ask:", outval[1].split()[0])
-            return outval[1].split()[0] # return only the value without the unit
-        # returns the complete output (for version information)
-        return output

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300sim.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300sim.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""
+File:    ANC300sim.py
+Date:    Jan 2020
+Author:  Michael Wagener, FZJ / ZEA-2, m.wagener@fz-juelich.de
+Purpose: Simulation for the Attocube ANC300 driver in the same way as
+         it is used in our lab.
+"""
+
+# if set to True, every communication line is printed
+_USE_DEBUG = False
+
+
+class MockComHandle:
+    '''
+    Simulate the API needed for the communication.
+    '''
+    
+    # List of possible commands asked the instrument to give a realistic answer.
+    cmddef = {'ver': ['attocube ANC300 controller version 1.1.0-1304 2013-10-17 08:16',
+                      'ANC150 compatibillity console'],
+              'getcser' : ['ANC300B-C-1514-3006076'],
+              'getser 1': ['ANM150A-M-1545-3010045'],
+              'getser 2': ['ANM150A-M-1545-3010041'],
+              'getser 3': ['Wrong axis type','ERROR'],
+              'getser 4': ['Wrong axis type','ERROR'],
+              'getser 5': ['Wrong axis type','ERROR'],
+              'getser 6': ['Wrong axis type','ERROR'],
+              'getser 7': ['Wrong axis type','ERROR'],
+
+              'getf 1': ['frequency = 210 Hz'],
+              'getf 2': ['frequency = 210 Hz'],
+              'getf 3': ['Wrong axis type','ERROR'],
+              'getf 4': ['Wrong axis type','ERROR'],
+              'getf 5': ['Wrong axis type','ERROR'],
+              'getf 6': ['Wrong axis type','ERROR'],
+              'getf 7': ['Wrong axis type','ERROR'],
+
+              'getv 1': ['voltage = 20.000000 V'],
+              'getv 2': ['voltage = 20.000000 V'],
+              'getv 3': ['Wrong axis type','ERROR'],
+              'getv 4': ['Wrong axis type','ERROR'],
+              'getv 5': ['Wrong axis type','ERROR'],
+              'getv 6': ['Wrong axis type','ERROR'],
+              'getv 7': ['Wrong axis type','ERROR'],
+
+              'geta 1': ['voltage = 0.000000 V'],
+              'geta 2': ['voltage = 0.000000 V'],
+              'geta 3': ['Wrong axis type','ERROR'],
+              'geta 4': ['Wrong axis type','ERROR'],
+              'geta 5': ['Wrong axis type','ERROR'],
+              'geta 6': ['Wrong axis type','ERROR'],
+              'geta 7': ['Wrong axis type','ERROR'],
+
+              'getm 1': ['mode = gnd'],
+              'getm 2': ['mode = gnd'],
+              'getm 3': ['Wrong axis type','ERROR'],
+              'getm 4': ['Wrong axis type','ERROR'],
+              'getm 5': ['Wrong axis type','ERROR'],
+              'getm 6': ['Wrong axis type','ERROR'],
+              'getm 7': ['Wrong axis type','ERROR'],
+
+              'getaci 1': ['acin = off'],
+              'getaci 2': ['acin = off'],
+              'getaci 3': ['Wrong axis type','ERROR'],
+              'getaci 4': ['Wrong axis type','ERROR'],
+              'getaci 5': ['Wrong axis type','ERROR'],
+              'getaci 6': ['Wrong axis type','ERROR'],
+              'getaci 7': ['Wrong axis type','ERROR'],
+
+              'getdci 1': ['dcin = off'],
+              'getdci 2': ['dcin = off'],
+              'getdci 3': ['Wrong axis type','ERROR'],
+              'getdci 4': ['Wrong axis type','ERROR'],
+              'getdci 5': ['Wrong axis type','ERROR'],
+              'getdci 6': ['Wrong axis type','ERROR'],
+              'getdci 7': ['Wrong axis type','ERROR'],
+
+              'gettu 1': ['trigger = off'],
+              'gettu 2': ['trigger = 2'],
+              'gettu 3': ['Wrong axis type','ERROR'],
+              'gettu 4': ['Wrong axis type','ERROR'],
+              'gettu 5': ['Wrong axis type','ERROR'],
+              'gettu 6': ['Wrong axis type','ERROR'],
+              'gettu 7': ['Wrong axis type','ERROR'],
+
+              'gettd 1': ['trigger = 1'],
+              'gettd 2': ['trigger = 3'],
+              'gettd 3': ['Wrong axis type','ERROR'],
+              'gettd 4': ['Wrong axis type','ERROR'],
+              'gettd 5': ['Wrong axis type','ERROR'],
+              'gettd 6': ['Wrong axis type','ERROR'],
+              'gettd 7': ['Wrong axis type','ERROR'],
+
+              'stepu 1': ['0'],
+              'stepu 2': ['0'],
+              'stepd 1': ['0'],
+              'stepd 2': ['0'],
+              # There is no simulation for the correct movement
+
+              }
+    
+    def __init__(self):
+        if _USE_DEBUG:
+            print("DBG-Mock: init")
+        self.closed = False
+        self.answer = []
+
+    def clear(self):
+        if _USE_DEBUG:
+            print("DBG-Mock: clear")
+
+    def close(self):
+        # make it an error to ask or write after close
+        if _USE_DEBUG:
+            print("DBG-Mock: close")
+        self.closed = True
+
+    def write(self, cmd):
+        global cmddef
+        if self.closed:
+            raise RuntimeError("Trying to write to a closed instrument")
+        cmd = cmd.decode('ascii').rstrip()
+        if _USE_DEBUG:
+            print("DBG-Mock: write", cmd)
+        # setxx <axis> <val> --> <kenn> = <val> <unit>
+        # getxx <axis> <val> --> <kenn> = <val> <unit>
+        if cmd.startswith('set'):
+            self.answer = [ cmd, 'OK' ]
+            tmp = cmd.split()
+            cmd = tmp[0].replace('set','get') + ' ' + tmp[1]
+            if cmd in self.cmddef:
+                val = self.cmddef[cmd]
+                if isinstance( val, (list, tuple) ):
+                    val = val[0]
+            else:
+                val = ""
+            val = val.split(' = ')
+            if len(val) == 2:
+                unit = val[1].split()
+                if len(unit) > 1:
+                    unit = unit[1]
+                else:
+                    unit = unit[0]
+                setval = [ val[0]+' = '+tmp[2]+' '+unit ]
+                self.cmddef.update( {cmd: setval} )
+            else:
+                self.cmddef.update( {cmd: tmp[2]} )
+            return
+        if cmd in self.cmddef:
+            self.answer = [ cmd ]
+            for c in self.cmddef[cmd]:
+                self.answer.append(c)
+            if self.answer[-1] != 'ERROR':
+                self.answer.append( 'OK' )
+            return
+        self.answer = [ cmd, 'OK' ]
+
+    def readline(self):
+        if _USE_DEBUG:
+            print("DBG-Mock: readline", self.answer)
+        if len(self.answer) > 0:
+            return self.answer.pop(0).encode('ascii')
+        return 'ERROR'.encode('ascii')

--- a/qcodes_contrib_drivers/drivers/Attocube/ANC300sim.py
+++ b/qcodes_contrib_drivers/drivers/Attocube/ANC300sim.py
@@ -117,7 +117,6 @@ class MockComHandle:
         self.closed = True
 
     def write(self, cmd):
-        global cmddef
         if self.closed:
             raise RuntimeError("Trying to write to a closed instrument")
         cmd = cmd.decode('ascii').rstrip()


### PR DESCRIPTION
The test device has the ANC300 controller and two ANM150 axis
modules. Therefore no automatic test for other modules is
included in the driver (no tests possible).
The communication is done via PySerial. The ANC300sim.py is
included to simulate the correct answers from the device.
Activate the simulation with a flag in the ANC300.py file.