### PR TITLE
Driver/ni daq

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/anaconda3/envs/qalamari/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/anaconda3/envs/qalamari/bin/python"
-}

--- a/docs/examples/NationalInstruments_DAQ.ipynb
+++ b/docs/examples/NationalInstruments_DAQ.ipynb
@@ -9,6 +9,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This was written for/tested with [National Instruments USB-6363 DAQ](https://www.ni.com/en-us/support/model.usb-6363.html), but the [nidaqmx](https://nidaqmx-python.readthedocs.io/en/latest/) API is pretty general, so I expect it will work with other devices\n",
+    "with minimal changes. The driver currently only supports analog inputs and outputs, no digital I/O."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/examples/NationalInstruments_DAQ.ipynb
+++ b/docs/examples/NationalInstruments_DAQ.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "National Instruments Multifunction DAQ example\n",
+    "======================================="
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/examples/NationalInstruments_DAQ.ipynb
+++ b/docs/examples/NationalInstruments_DAQ.ipynb
@@ -112,6 +112,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.8"
+  },
+  "nbsphinx": {
+   "execute": "never"
   }
  },
  "nbformat": 4,

--- a/docs/examples/NationalInstruments_DAQ.ipynb
+++ b/docs/examples/NationalInstruments_DAQ.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nidaqmx\n",
+    "from qcodes_contrib_drivers.drivers.NationalInstruments.DAQ import DAQAnalogInputs, DAQAnalogOutputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DAQAnalogInputs`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Acquire 1 million points simultaneously on `num_ai_channels` with a sample rate of 1 MHz, averaging the acquired data down to 100 thousand points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devname = 'Dev0' # can be found with NI-MAX\n",
+    "sample_rate_per_channel = 1e6 # Hz\n",
+    "num_ai_channels = 5\n",
+    "ai_channels = {'meas{}'.format(i): i for i in range(num_ai_channels)}\n",
+    "num_samples_raw = 1e6\n",
+    "num_samples_averaged = 1e5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with nidaqmx.Task('ai_task') as ai_task:\n",
+    "    daq_ai = DAQAnalogInputs(\n",
+    "        'daq_ai',\n",
+    "        devname,\n",
+    "        sample_rate_per_channel,\n",
+    "        ai_channels,\n",
+    "        ai_task,\n",
+    "        samples_to_read=num_samples_raw,\n",
+    "        target_points=num_samples_averaged,\n",
+    "    )\n",
+    "    ai_task.start()\n",
+    "    result = daq_ai.voltage() # result.shape == (num_ai_channels, num_samples_averaged)\n",
+    "    ai_task.wait_until_done()\n",
+    "    ai_task.stop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For an example of synchronously writing and acquiring data on many channels, see the [`scanning-squid` docs](https://scanning-squid.readthedocs.io/en/latest/), in particular [`microscope.susceptometer.Susceptometer.scan_surface`](https://scanning-squid.readthedocs.io/en/latest/_modules/microscope/susceptometer.html#SusceptometerMicroscope.scan_surface) and [`scanner.Scanner.scan_line`](https://scanning-squid.readthedocs.io/en/latest/_modules/scanner.html#Scanner.scan_line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `DAQAnalogOutputs`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`DAQAnalogOutputs` functions as a simple multichannel DC DAC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devname = 'Dev0' # can be found with NI-MAX\n",
+    "ao_channels = {str(i): i for i in range(5)}\n",
+    "daq_ao = DAQAnalogOutputs('daq_ao', devname, ao_channels)\n",
+    "daq_ao.voltage_0(5)\n",
+    "daq_ao.voltage_4(2.2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
@@ -1,7 +1,9 @@
 """Qcodes drivers for National Instrument mutlifunction I/O devices (DAQs).
 
+Requires nidaqmx package: https://nidaqmx-python.readthedocs.io/en/latest/
+
 This was written for/tested with National Instruments USB-6363 DAQ,
-but the nidaqmx API is pretty general, so I expect they will work with other devices
+but the nidaqmx API is pretty general, so I expect it will work with other devices
 with minimal changes.
 
 For an example of synchronously writing data to multiple analog outputs and

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
@@ -164,3 +164,4 @@ class DAQAnalogOutputs(Instrument):
                 label='Voltage',
                 unit='V'
             )
+            

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
@@ -1,0 +1,163 @@
+"""Qcodes drivers for National Instrument mutlifunction I/O devices (DAQs).
+
+This was written for/tested with National Instruments USB-6363 DAQ,
+but the nidaqmx API is pretty general, so I expect they will work with other devices
+with minimal changes.
+
+For an example of synchronously writing data to multiple analog outputs and
+acquiring data on multiple analog inputs, see
+https://scanning-squid.readthedocs.io/en/latest/_modules/microscope/susceptometer.html#SusceptometerMicroscope.scan_surface
+"""
+
+from typing import Dict, Optional, Sequence, Any, Union
+import numpy as np
+
+import nidaqmx
+from nidaqmx.constants import AcquisitionType, TaskMode
+from qcodes.instrument.base import Instrument
+from qcodes.instrument.parameter import Parameter, ArrayParameter
+
+class DAQAnalogInputVoltages(ArrayParameter):
+    """Acquires data from one or several DAQ analog inputs.
+
+    Args:
+        name: Name of parameter (usually 'voltage').
+        task: nidaqmx.Task with appropriate analog inputs channels.
+        samples_to_read: Number of samples to read. Will be averaged based on shape.
+        shape: Desired shape of averaged array, i.e. (nchannels, target_points).
+        timeout: Acquisition timeout in seconds.
+        kwargs: Keyword arguments to be passed to ArrayParameter constructor.
+    """
+    def __init__(self, name: str, task: Any, samples_to_read: int,
+                 shape: Sequence[int], timeout: Union[float, int], **kwargs) -> None:
+        super().__init__(name, shape, **kwargs)
+        self.task = task
+        self.nchannels, self.target_points = shape
+        self.samples_to_read = samples_to_read
+        self.timeout = timeout
+        
+    def get_raw(self):
+        """Averages data to get `self.target_points` points per channel.
+        If `self.target_points` == `self.samples_to_read`, no averaging is done.
+        """
+        data_raw = np.array(self.task.read(number_of_samples_per_channel=self.samples_to_read, timeout=self.timeout))
+        return np.mean(np.reshape(data_raw, (self.nchannels, self.target_points, -1)), 2)
+    
+class DAQAnalogInputs(Instrument):
+    """Instrument to acquire DAQ analog input data in a qcodes Loop or measurement.
+
+    Args:
+        name: Name of instrument (usually 'daq_ai').
+        dev_name: NI DAQ device name (e.g. 'Dev1').
+        rate: Desired DAQ sampling rate per channel in Hz.
+        channels: Dict of analog input channel configuration.
+        task: fresh nidaqmx.Task to be populated with ai_channels.
+        min_val: minimum of input voltage range (-0.1, -0.2, -0.5, -1, -2, -5 [default], or -10)
+        max_val: maximum of input voltage range (0.1, 0.2, 0.5, 1, 2, 5 [default], or 10)
+        clock_src: Sample clock source for analog inputs. Default: None
+        samples_to_read: Number of samples to acquire from the DAQ
+            per channel per measurement/loop iteration.
+            Default: 2 (minimum number of samples DAQ will acquire in this timing mode).
+        target_points: Number of points per channel we want in our final array.
+            samples_to_read will be averaged down to target_points.
+        timeout: Acquisition timeout in seconds. Default: 60.
+        kwargs: Keyword arguments to be passed to Instrument constructor.
+    """
+    def __init__(self, name: str, dev_name: str, rate: Union[int, float], channels: Dict[str, int],
+                 task: Any, min_val: Optional[float]=-5, max_val: Optional[float]=5,
+                 clock_src: Optional[str]=None, samples_to_read: Optional[int]=2,
+                 target_points: Optional[int]=None, timeout: Optional[Union[float, int]]=60, **kwargs) -> None:
+        super().__init__(name, **kwargs)
+        if target_points is None:
+            if samples_to_read == 2: # minimum number of samples DAQ will read in this timing mode
+                target_points = 1
+            else:
+                target_points = samples_to_read
+        self.rate = rate
+        nchannels = len(channels)
+        self.samples_to_read = samples_to_read
+        self.task = task
+        self.metadata.update({
+            'dev_name': dev_name,
+            'rate': '{} Hz'.format(rate),
+            'channels': channels})
+        for ch, idx in channels.items():
+            channel = '{}/ai{}'.format(dev_name, idx)
+            self.task.ai_channels.add_ai_voltage_chan(channel, ch, min_val=min_val, max_val=max_val)
+        if clock_src is None:
+            # Use default sample clock timing: ai/SampleClockTimebase
+            self.task.timing.cfg_samp_clk_timing(
+                rate,
+                sample_mode=AcquisitionType.FINITE,
+                samps_per_chan=samples_to_read)
+        else:
+            # Clock the inputs on some other clock signal, e.g. ao/SampleClock for synchronous acquisition
+            self.task.timing.cfg_samp_clk_timing(
+                    rate,
+                    source=clock_src,
+                    sample_mode=AcquisitionType.FINITE,
+                    samps_per_chan=samples_to_read
+            )
+        # We need a parameter in order to acquire voltage in a qcodes Loop or Measurement
+        self.add_parameter(
+            name='voltage',
+            parameter_class=DAQAnalogInputVoltages,
+            task=self.task,
+            samples_to_read=samples_to_read,
+            shape=(nchannels, target_points),
+            timeout=timeout,
+            label='Voltage',
+            unit='V'
+        ) 
+
+class DAQAnalogOutputVoltage(Parameter):
+    """Writes data to one or several DAQ analog outputs.
+
+    Args:
+        name: Name of parameter (usually 'voltage').
+        dev_name: DAQ device name (e.g. 'Dev1').
+        idx: AO channel inde.
+        **kwargs: Keyword arguments to be passed to ArrayParameter constructor.
+    """
+    def __init__(self, name: str, dev_name: str, idx: int, **kwargs) -> None:
+        super().__init__(name, **kwargs)
+        self.dev_name = dev_name
+        self.idx = idx
+        self.voltage = '?'
+     
+    def set_raw(self, voltage: Union[int, float]) -> None:
+        with nidaqmx.Task('daq_ao_task') as ao_task:
+            channel = '{}/ao{}'.format(self.dev_name, self.idx)
+            ao_task.ao_channels.add_ao_voltage_chan(channel, self.name)
+            ao_task.write(voltage, auto_start=True)
+        self.voltage = voltage
+
+    def get_raw(self):
+        """Returns last voltage array written to outputs.
+        """
+        return self.voltage
+
+class DAQAnalogOutputs(Instrument):
+    """Instrument to write DAQ analog output data in a qcodes Loop or measurement.
+
+    Args:
+        name: Name of instrument (usually 'daq_ao').
+        dev_name: NI DAQ device name (e.g. 'Dev1').
+        channels: Dict of analog output channel configuration.
+        **kwargs: Keyword arguments to be passed to Instrument constructor.
+    """
+    def __init__(self, name: str, dev_name: str, channels: Dict[str, int], **kwargs) -> None:
+        super().__init__(name, **kwargs)
+        self.metadata.update({
+            'dev_name': dev_name,
+            'channels': channels})
+        # We need parameters in order to write voltages in a qcodes Loop or Measurement
+        for ch, idx in channels.items():
+            self.add_parameter(
+                name='voltage_{}'.format(ch.lower()),
+                dev_name=dev_name,
+                idx=idx,
+                parameter_class=DAQAnalogOutputVoltage,
+                label='Voltage',
+                unit='V'
+            )

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
@@ -81,10 +81,10 @@ class DAQAnalogInputs(Instrument):
         self.task = task
         self.metadata.update({
             'dev_name': dev_name,
-            'rate': '{} Hz'.format(rate),
+            'rate': f'{rate} Hz',
             'channels': channels})
         for ch, idx in channels.items():
-            channel = '{}/ai{}'.format(dev_name, idx)
+            channel = f'{dev_name}/ai{idx}'
             self.task.ai_channels.add_ai_voltage_chan(channel, ch, min_val=min_val, max_val=max_val)
         if clock_src is None:
             # Use default sample clock timing: ai/SampleClockTimebase
@@ -130,7 +130,7 @@ class DAQAnalogOutputVoltage(Parameter):
      
     def set_raw(self, voltage: Union[int, float]) -> None:
         with nidaqmx.Task('daq_ao_task') as ao_task:
-            channel = '{}/ao{}'.format(self.dev_name, self.idx)
+            channel = f'{self.dev_name}/ao{self.idx}'
             ao_task.ao_channels.add_ao_voltage_chan(channel, self.name)
             ao_task.write(voltage, auto_start=True)
         self._voltage = voltage
@@ -157,7 +157,7 @@ class DAQAnalogOutputs(Instrument):
         # We need parameters in order to write voltages in a qcodes Loop or Measurement
         for ch, idx in channels.items():
             self.add_parameter(
-                name='voltage_{}'.format(ch.lower()),
+                name=f'voltage_{ch.lower()}',
                 dev_name=dev_name,
                 idx=idx,
                 parameter_class=DAQAnalogOutputVoltage,

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/DAQ.py
@@ -111,31 +111,32 @@ class DAQAnalogInputs(Instrument):
         ) 
 
 class DAQAnalogOutputVoltage(Parameter):
-    """Writes data to one or several DAQ analog outputs.
+    """Writes data to one or several DAQ analog outputs. This only writes one channel at a time,
+    since Qcodes ArrayParameters are not settable.
 
     Args:
         name: Name of parameter (usually 'voltage').
         dev_name: DAQ device name (e.g. 'Dev1').
-        idx: AO channel inde.
-        **kwargs: Keyword arguments to be passed to ArrayParameter constructor.
+        idx: AO channel index.
+        kwargs: Keyword arguments to be passed to ArrayParameter constructor.
     """
     def __init__(self, name: str, dev_name: str, idx: int, **kwargs) -> None:
         super().__init__(name, **kwargs)
         self.dev_name = dev_name
         self.idx = idx
-        self.voltage = '?'
+        self._voltage = np.nan
      
     def set_raw(self, voltage: Union[int, float]) -> None:
         with nidaqmx.Task('daq_ao_task') as ao_task:
             channel = '{}/ao{}'.format(self.dev_name, self.idx)
             ao_task.ao_channels.add_ao_voltage_chan(channel, self.name)
             ao_task.write(voltage, auto_start=True)
-        self.voltage = voltage
+        self._voltage = voltage
 
     def get_raw(self):
         """Returns last voltage array written to outputs.
         """
-        return self.voltage
+        return self._voltage
 
 class DAQAnalogOutputs(Instrument):
     """Instrument to write DAQ analog output data in a qcodes Loop or measurement.


### PR DESCRIPTION
Driver for National Instruments multifunction DAQ devices (https://www.ni.com/en-us/shop/select/multifunction-io-device). Requires the nidaqmx python package from National Instruments (https://nidaqmx-python.readthedocs.io/en/latest/).