### PR TITLE
Driver/zurich hf2li

### DIFF
--- a/docs/examples/ZurichInstruments_HF2LI.ipynb
+++ b/docs/examples/ZurichInstruments_HF2LI.ipynb
@@ -94,6 +94,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.8"
+  },
+  "nbsphinx": {
+   "execute": "never"
   }
  },
  "nbformat": 4,

--- a/docs/examples/ZurichInstruments_HF2LI.ipynb
+++ b/docs/examples/ZurichInstruments_HF2LI.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qcodes_contrib_drivers.drivers.ZurichInstruments.HF2LI import HF2LI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A single instance of `HF2LI` represents a single-channel lock-in amplifier, comprised of a single demodulator, a single excitation output (sigout), and whatever auxiliary outputs you want to use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devname = 'dev200' # device name according to the ZI software\n",
+    "demod = 0 # index of demodulator to use\n",
+    "sigout = 0 # index of sigout channel to use\n",
+    "auxouts = {'X': 0, 'Y': 3} # make this an empty dict if you don't want to use auxouts\n",
+    "\n",
+    "lia = HF2LI('lia', devname, demod, sigout, auxouts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lia.time_constant(1e-3) # s\n",
+    "lia.phase(0) # \n",
+    "lia.X() # in-phase component\n",
+    "lia.Y() # quadrature component"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make a second instance using different hardware channels of the same device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demod1 = 3\n",
+    "sigout1 = 1\n",
+    "auxouts1 = {'R': 1, 'Theta': 2}\n",
+    "\n",
+    "lia1 = HF2LI('lia1', devname, demod1, sigout1, auxouts1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lia1.time_constant(1e-1) # s\n",
+    "lia1.phase(90) # degrees\n",
+    "lia1.frequency(19.9e3) # Hz\n",
+    "lia1.R() # magnitude\n",
+    "lia1.Theta() # phase\n",
+    "output_amplitude = lia1.sigout_amplitude() * lia1.sigout_range() # V"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/ZurichInstruments_HF2LI.ipynb
+++ b/docs/examples/ZurichInstruments_HF2LI.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Zurich Instruments HF2LI example\n",
+    "==========================="
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/examples/ZurichInstruments_HF2LI.ipynb
+++ b/docs/examples/ZurichInstruments_HF2LI.ipynb
@@ -9,19 +9,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [Zurich Instruments HF2LI](https://www.zhinst.com/americas/products/hf2li-lock-amplifier) is a 50 MHz lock-in amplifier that contains essentially two independent signal generators and lock-in units.\n",
+    "\n",
+    "A single instance of `HF2LI` represents a single-channel lock-in amplifier, comprised of a single demodulator, a single excitation output (sigout), and whatever auxiliary outputs you want to use, e.g. (X, Y) or (R, Theta)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from qcodes_contrib_drivers.drivers.ZurichInstruments.HF2LI import HF2LI"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A single instance of `HF2LI` represents a single-channel lock-in amplifier, comprised of a single demodulator, a single excitation output (sigout), and whatever auxiliary outputs you want to use."
    ]
   },
   {
@@ -79,9 +81,13 @@
     "lia1.time_constant(1e-1) # s\n",
     "lia1.phase(90) # degrees\n",
     "lia1.frequency(19.9e3) # Hz\n",
+    "# set the excitation output amplitude to 100 mV\n",
+    "lia1.sigout_range(1.0) \n",
+    "lia.sigout_amplitude0(0.1)\n",
+    "output_amplitude = lia1.sigout_amplitude0() * lia1.sigout_range() # V\n",
+    "\n",
     "lia1.R() # magnitude\n",
-    "lia1.Theta() # phase\n",
-    "output_amplitude = lia1.sigout_amplitude() * lia1.sigout_range() # V"
+    "lia1.Theta() # phase"
    ]
   }
  ],

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -232,3 +232,4 @@ class HF2LI(Instrument):
     def sample(self):
         path = f'/{self.dev_id}/demods/{self.demod}/sample/'
         return self.daq.getSample(path)
+        

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -157,7 +157,7 @@ class HF2LI(Instrument):
         path = f'/{self.dev_id}/demods/{self.demod}/phaseshift/'
         self.daq.setDouble(path, phase)
         
-    def _get_gain(self, channel: float) -> float:
+    def _get_gain(self, channel: str) -> float:
         path = f'/{self.devid}/auxouts/{self.auxouts[channel]}/scale/'
         return self.daq.getDouble(path)
 

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -16,6 +16,9 @@ class HF2LI(Instrument):
     and multiple auxout channels (for X, Y, R, Theta, or an arbitrary manual value).
     Multiple instances can be run simultaneously as independent lockin amplifiers.
 
+    This instrument has a great deal of additional functionality that is
+    not currently supported by this driver.
+
     Args:
         name: Name of instrument.
         device: Device name, e.g. "dev204", used to create zhinst API session.

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -3,7 +3,7 @@ import numpy as np
 import logging
 log = logging.getLogger(__name__)
 
-import zhinst.ziPython, zhinst.utils
+import zhinst.utils
 import qcodes as qc
 from qcodes.instrument.base import Instrument
 import qcodes.utils.validators as vals
@@ -17,193 +17,220 @@ class HF2LI(Instrument):
     Multiple instances can be run simultaneously as independent lockin amplifiers.
 
     Args:
-        name (str): Name of instrument.
-        device (str): Device name, e.g. "dev204", used to create zhinst API session.
-        demod (int): Index of the demodulator to use.
-        sigout (int): Index of the sigout channel to use as excitation source.
-        auxouts (dict[str, int]): Dict of the form {output: index},
+        name: Name of instrument.
+        device: Device name, e.g. "dev204", used to create zhinst API session.
+        demod: Index of the demodulator to use.
+        sigout: Index of the sigout channel to use as excitation source.
+        auxouts: Dict of the form {output: index},
             where output is a key of HF2LI.OUTPUT_MAPPING, for example {"X": 0, "Y": 3}
             to use the instrument as a lockin amplifier in X-Y mode with auxout channels 0 and 3.
+        num_sigout_mixer_channels: Number of mixer channels to enable on the sigouts. Default: 1.
     """
     OUTPUT_MAPPING = {-1: 'manual', 0: 'X', 1: 'Y', 2: 'R', 3: 'Theta'}
     def __init__(self, name: str, device: str, demod: int, sigout: int,
-        auxouts: Dict[str, int], **kwargs) -> None:
+        auxouts: Dict[str, int], num_sigout_mixer_channels: int=1, **kwargs) -> None:
         super().__init__(name, **kwargs)
         instr = zhinst.utils.create_api_session(device, 1, required_devtype='HF2LI')
         self.daq, self.dev_id, self.props = instr
         self.demod = demod
         self.sigout = sigout
         self.auxouts = auxouts
-        log.info('Successfully connected to {}.'.format(name))
+        log.info(f'Successfully connected to {name}.')
 
         for ch in self.auxouts:
-            self.add_parameter(name=ch,
-                               label='Scaled {} output value'.format(ch),
-                               unit='V',
-                               get_cmd=lambda ch=ch: self._get_output_value(channel=ch),
-                               get_parser=float
-                               )
-            self.add_parameter(name='gain_{}'.format(ch),
-                               label='{} output gain'.format(ch),
-                               unit='V/Vrms',
-                               get_cmd=lambda ch=ch: self._get_gain(channel=ch),
-                               get_parser=float,
-                               set_cmd=lambda gain, ch=ch: self._set_gain(gain, channel=ch),
-                               vals=vals.Numbers()
-                               )
-            self.add_parameter(name='offset_{}'.format(ch),
-                               label='{} output offset'.format(ch),
-                               unit='V',
-                               get_cmd=lambda ch=ch: self._get_offset(channel=ch),
-                               get_parser=float,
-                               set_cmd=lambda offset, ch=ch: self._set_offset(offset, channel=ch),
-                               vals=vals.Numbers(-2560, 2560)
-                               )
-            self.add_parameter(name='output_{}'.format(ch),
-                               label='{} outptut select'.format(ch),
-                               unit='',
-                               get_cmd=lambda ch=ch: self._get_output_select(channel=ch),
-                               get_parser=str,
-                            #    set_cmd=lambda output, ch=ch: self._set_output_select(output, channel=ch),
-                            #    vals=vals.Ints(-1,3)
-                               )
-            self._set_output_select(channel=ch)
+            self.add_parameter(
+                name=ch,
+                label=f'Scaled {ch} output value',
+                unit='V',
+                get_cmd=lambda channel=ch: self._get_output_value(channel),
+                get_parser=float,
+                docstring=f'Scaled and demodulated {ch} value.'
+            )
+            self.add_parameter(
+                name=f'gain_{ch}',
+                label=f'{ch} output gain',
+                unit='V/Vrms',
+                get_cmd=lambda channel=ch: self._get_gain(channel),
+                get_parser=float,
+                set_cmd=lambda gain, channel=ch: self._set_gain(gain, channel),
+                vals=vals.Numbers(),
+                docstring=f'Gain factor for {ch}.'
+            )
+            self.add_parameter(
+                name=f'offset_{ch}',
+                label=f'{ch} output offset',
+                unit='V',
+                get_cmd=lambda channel=ch: self._get_offset(channel),
+                get_parser=float,
+                set_cmd=lambda offset, channel=ch: self._set_offset(offset, channel),
+                vals=vals.Numbers(-2560, 2560),
+                docstring=f'Manual offset for {ch}, applied after scaling.'
+            )
+            self.add_parameter(
+                name=f'output_{ch}',
+                label=f'{ch} outptut select',
+                get_cmd=lambda channel=ch: self._get_output_select(channel),
+                get_parser=str,
+                # making this only gettable since we are explicitly mapping
+                # auxouts to X, Y, R, Theta, etc.
+                # set_cmd=lambda output, channel=ch: self._set_output_select(output, channel),
+                # vals=vals.Ints(-1,3)
+            )
+            self._set_output_select(ch)
             
-        self.add_parameter(name='phase',
-                           label='Phase',
-                           unit='deg',
-                           get_cmd=self._get_phase,
-                           get_parser=float,
-                           set_cmd=self._set_phase,
-                           vals=vals.Numbers(-180,180)
-                           )
-        self.add_parameter(name='time_constant',
-                           label='Time constant',
-                           unit='s',
-                           get_cmd=self._get_time_constant,
-                           get_parser=float,
-                           set_cmd=self._set_time_constant,
-                           vals=vals.Numbers()
-                           )  
-        self.add_parameter(name='frequency',
-                           label='Frequency',
-                           unit='Hz',
-                           get_cmd=self._get_frequency,
-                           get_parser=float
-                           ) 
-        self.add_parameter(name='sigout_range',
-                           label='Signal output range',
-                           unit='V',
-                           get_cmd=self._get_sigout_range,
-                           get_parser=float,
-                           set_cmd=self._set_sigout_range,
-                           vals=vals.Enum(0.01, 0.1, 1, 10),
-                           snapshot_get=False
-                           )
-        self.add_parameter(name='sigout_offset',
-                           label='Signal output offset',
-                           unit='V',
-                           get_cmd=self._get_sigout_offset,
-                           get_parser=float,
-                           set_cmd=self._set_sigout_offset,
-                           vals=vals.Numbers(-1, 1),
-                           snapshot_get=False
-                           )
-        self.add_parameter(name='sigout_amplitude',
-                           label='Signal output amplitude',
-                           unit='V',
-                           get_cmd=self._get_sigout_amplitude,
-                           get_parser=float,
-                           set_cmd=self._set_sigout_amplitude,
-                           vals=vals.Numbers(-1, 1),
-                           snapshot_get=False
-                           )
+        self.add_parameter(
+            name='phase',
+            label='Phase',
+            unit='deg',
+            get_cmd=self._get_phase,
+            get_parser=float,
+            set_cmd=self._set_phase,
+            vals=vals.Numbers(-180,180)
+        )
+        self.add_parameter(
+            name='time_constant',
+            label='Time constant',
+            unit='s',
+            get_cmd=self._get_time_constant,
+            get_parser=float,
+            set_cmd=self._set_time_constant,
+            vals=vals.Numbers()
+        )  
+        self.add_parameter(
+            name='frequency',
+            label='Frequency',
+            unit='Hz',
+            get_cmd=self._get_frequency,
+            get_parser=float
+        ) 
+        self.add_parameter(
+            name='sigout_range',
+            label='Signal output range',
+            unit='V',
+            get_cmd=self._get_sigout_range,
+            get_parser=float,
+            set_cmd=self._set_sigout_range,
+            vals=vals.Enum(0.01, 0.1, 1, 10)
+        )
+        self.add_parameter(
+            name='sigout_offset',
+            label='Signal output offset',
+            unit='V',
+            get_cmd=self._get_sigout_offset,
+            get_parser=float,
+            set_cmd=self._set_sigout_offset,
+            vals=vals.Numbers(-1, 1),
+            docstring='Multiply by sigout_range to get actual offset voltage.'
+        )
+        for i in range(num_sigout_mixer_channels):
+            self.add_parameter(
+                name=f'sigout_enable{i}',
+                label=f'Signal output mixer {i} enable',
+                get_cmd=lambda mixer_channel=i: self._get_sigout_enable(mixer_channel),
+                get_parser=float,
+                set_cmd=lambda amp, mixer_channel=i: self._set_sigout_enable(mixer_channel, amp),
+                vals=vals.Enum(0,1,2,3),
+                docstring="""\
+                0: Channel off (unconditionally)
+                1: Channel on (unconditionally)
+                2: Channel off (will be turned off on next change of sign from negative to positive)
+                3: Channel on (will be turned on on next change of sign from negative to positive)
+                """
+            )
+            self.add_parameter(
+                name=f'sigout_amplitude{i}',
+                label=f'Signal output mixer {i} amplitude',
+                unit='Gain',
+                get_cmd=lambda mixer_channel=i: self._get_sigout_amplitude(mixer_channel),
+                get_parser=float,
+                set_cmd=lambda amp, mixer_channel=i: self._set_sigout_amplitude(mixer_channel, amp),
+                vals=vals.Numbers(-1, 1),
+                docstring='Multiply by sigout_range to get actual output voltage.'
+            )
 
     def _get_phase(self):
-        path = '/{}/demods/{}/phaseshift/'.format(self.dev_id, self.demod)
-        phase = self.daq.getDouble(path)
-        return phase
+        path = f'/{self.dev_id}/demods/{self.demod}/phaseshift/'
+        return self.daq.getDouble(path)
 
     def _set_phase(self, phase):
-        path = '/{}/demods/{}/phaseshift/'.format(self.dev_id, self.demod)
+        path = f'/{self.dev_id}/demods/{self.demod}/phaseshift/'
         self.daq.setDouble(path, phase)
         
-    def _get_gain(self, channel=None):
-        path = '/{}/auxouts/{}/scale/'.format(self.dev_id, self.auxouts[channel])
-        gain = self.daq.getDouble(path)
-        return gain
+    def _get_gain(self, channel):
+        path = f'/{self.devid}/auxouts/{self.auxouts[channel]}/scale/'
+        return self.daq.getDouble(path)
 
-    def _set_gain(self, gain, channel=None):
-        path = '/{}/auxouts/{}/scale/'.format(self.dev_id, self.auxouts[channel])
+    def _set_gain(self, gain, channel):
+        path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/scale/'
         self.daq.setDouble(path, gain)
 
-    def _get_offset(self, channel=None):
-        path = '/{}/auxouts/{}/offset/'.format(self.dev_id, self.auxouts[channel])
-        gain = self.daq.getDouble(path)
-        return gain
+    def _get_offset(self, channel):
+        path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/offset/'
+        return self.daq.getDouble(path)
 
-    def _set_offset(self, offset, channel=None):
-        path = '/{}/auxouts/{}/offset/'.format(self.dev_id, self.auxouts[channel])
+    def _set_offset(self, offset, channel):
+        path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/offset/'
         self.daq.setDouble(path, offset)
 
-    def _get_output_value(self, channel=None):
-        path = '/{}/auxouts/{}/value/'.format(self.dev_id, self.auxouts[channel])
-        value = self.daq.getDouble(path)
-        return value
+    def _get_output_value(self, channel):
+        path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/value/'
+        return self.daq.getDouble(path)
 
-    def _get_output_select(self, channel=None):
-        path = '/{}/auxouts/{}/outputselect/'.format(self.dev_id, self.auxouts[channel])
-        idx = int(self.daq.getDouble(path))
-        output = self.OUTPUT_MAPPING[idx]
-        return output
+    def _get_output_select(self, channel):
+        path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/outputselect/'
+        idx = self.daq.getInt(path)
+        return self.OUTPUT_MAPPING[idx]
 
-    def _set_output_select(self, channel=None):
-        path = '/{}/auxouts/{}/outputselect/'.format(self.dev_id, self.auxouts[channel])
+    def _set_output_select(self, channel):
+        path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/outputselect/'
         keys = list(self.OUTPUT_MAPPING.keys())
         idx = keys[list(self.OUTPUT_MAPPING.values()).index(channel)]
         self.daq.setInt(path, idx)
 
     def _get_time_constant(self):
-        path = '/{}/demods/{}/timeconstant/'.format(self.dev_id, self.demod)
-        tc = self.daq.getDouble(path)
-        return tc
+        path = f'/{self.dev_id}/demods/{self.demod}/timeconstant/'
+        return self.daq.getDouble(path)
 
     def _set_time_constant(self, tc):
-        path = '/{}/demods/{}/timeconstant/'.format(self.dev_id, self.demod)
+        path = f'/{self.dev_id}/demods/{self.demod}/timeconstant/'
         self.daq.setDouble(path, tc)
 
     def _get_sigout_range(self):
-        path = '/{}/sigouts/{}/range/'.format(self.dev_id, self.sigout[0])
-        range = self.daq.getDouble(path)
-        return range
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/range/'
+        return self.daq.getDouble(path)
 
     def _set_sigout_range(self, rng):
-        path = '/{}/sigouts/{}/range/'.format(self.dev_id, self.sigout[0])
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/range/'
         self.daq.setDouble(path, rng)
 
     def _get_sigout_offset(self):
-        path = '/{}/sigouts/{}/offset/'.format(self.dev_id, self.sigout[0])
-        range = self.daq.getDouble(path)
-        return range
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/offset/'
+        return self.daq.getDouble(path)
 
     def _set_sigout_offset(self, offset):
-        path = '/{}/sigouts/{}/offset/'.format(self.dev_id, self.sigout[0])
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/offset/'
         self.daq.setDouble(path, offset)
 
-    def _get_sigout_amplitude(self):
-        path = '/{}/sigouts/{}/amplitudes/{}/'.format(self.dev_id, self.sigout[0], self.sigout[1])
-        range = self.daq.getDouble(path)
-        return range
+    def _get_sigout_amplitude(self, mixer_channel):
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/amplitudes/{mixer_channel}/'
+        return self.daq.getDouble(path)
 
-    def _set_sigout_amplitude(self, amp):
-        path = '/{}/sigouts/{}/amplitudes/{}/'.format(self.dev_id, self.sigout[0], self.sigout[1])
+    def _set_sigout_amplitude(self, mixer_channel, amp):
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/amplitudes/{mixer_channel}/'
         self.daq.setDouble(path, amp)
 
+    def _get_sigout_enable(self, mixer_channel):
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/enables/{mixer_channel}/'
+        return self.daq.getInt(path)
+
+    def _set_sigout_enable(self, mixer_channel, val):
+        path = f'/{self.dev_id}/sigouts/{self.sigout}/enables/{mixer_channel}/'
+        self.daq.setInt(path, val)
+
     def _get_frequency(self):
-        path = '/{}/demods/{}/freq/'.format(self.dev_id, self.demod)
-        freq = self.daq.getDouble(path)
-        return freq
+        path = f'/{self.dev_id}/demods/{self.demod}/freq/'
+        return self.daq.getDouble(path)
 
     def sample(self):
-        path = '/{}/demods/{}/sample/'.format(self.dev_id, self.demod)
+        path = f'/{self.dev_id}/demods/{self.demod}/sample/'
         return self.daq.getSample(path)

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -1,0 +1,209 @@
+from typing import Dict, List, Optional, Sequence, Any, Union
+import numpy as np
+import logging
+log = logging.getLogger(__name__)
+
+import zhinst.ziPython, zhinst.utils
+import qcodes as qc
+from qcodes.instrument.base import Instrument
+import qcodes.utils.validators as vals
+
+class HF2LI(Instrument):
+    """Qcodes driver for Zurich Instruments HF2LI lockin amplifier.
+
+    This driver is meant to emulate a single-channel lockin amplifier,
+    so one instance has a single demodulator, a single sigout channel,
+    and multiple auxout channels (for X, Y, R, Theta, or an arbitrary manual value).
+    Multiple instances can be run simultaneously as independent lockin amplifiers.
+
+    Args:
+        name (str): Name of instrument.
+        device (str): Device name, e.g. "dev204", used to create zhinst API session.
+        demod (int): Index of the demodulator to use.
+        sigout (int): Index of the sigout channel to use as excitation source.
+        auxouts (dict[str, int]): Dict of the form {output: index},
+            where output is a key of HF2LI.OUTPUT_MAPPING, for example {"X": 0, "Y": 3}
+            to use the instrument as a lockin amplifier in X-Y mode with auxout channels 0 and 3.
+    """
+    OUTPUT_MAPPING = {-1: 'manual', 0: 'X', 1: 'Y', 2: 'R', 3: 'Theta'}
+    def __init__(self, name: str, device: str, demod: int, sigout: int,
+        auxouts: Dict[str, int], **kwargs) -> None:
+        super().__init__(name, **kwargs)
+        instr = zhinst.utils.create_api_session(device, 1, required_devtype='HF2LI')
+        self.daq, self.dev_id, self.props = instr
+        self.demod = demod
+        self.sigout = sigout
+        self.auxouts = auxouts
+        log.info('Successfully connected to {}.'.format(name))
+
+        for ch in self.auxouts:
+            self.add_parameter(name=ch,
+                               label='Scaled {} output value'.format(ch),
+                               unit='V',
+                               get_cmd=lambda ch=ch: self._get_output_value(channel=ch),
+                               get_parser=float
+                               )
+            self.add_parameter(name='gain_{}'.format(ch),
+                               label='{} output gain'.format(ch),
+                               unit='V/Vrms',
+                               get_cmd=lambda ch=ch: self._get_gain(channel=ch),
+                               get_parser=float,
+                               set_cmd=lambda gain, ch=ch: self._set_gain(gain, channel=ch),
+                               vals=vals.Numbers()
+                               )
+            self.add_parameter(name='offset_{}'.format(ch),
+                               label='{} output offset'.format(ch),
+                               unit='V',
+                               get_cmd=lambda ch=ch: self._get_offset(channel=ch),
+                               get_parser=float,
+                               set_cmd=lambda offset, ch=ch: self._set_offset(offset, channel=ch),
+                               vals=vals.Numbers(-2560, 2560)
+                               )
+            self.add_parameter(name='output_{}'.format(ch),
+                               label='{} outptut select'.format(ch),
+                               unit='',
+                               get_cmd=lambda ch=ch: self._get_output_select(channel=ch),
+                               get_parser=str,
+                            #    set_cmd=lambda output, ch=ch: self._set_output_select(output, channel=ch),
+                            #    vals=vals.Ints(-1,3)
+                               )
+            self._set_output_select(channel=ch)
+            
+        self.add_parameter(name='phase',
+                           label='Phase',
+                           unit='deg',
+                           get_cmd=self._get_phase,
+                           get_parser=float,
+                           set_cmd=self._set_phase,
+                           vals=vals.Numbers(-180,180)
+                           )
+        self.add_parameter(name='time_constant',
+                           label='Time constant',
+                           unit='s',
+                           get_cmd=self._get_time_constant,
+                           get_parser=float,
+                           set_cmd=self._set_time_constant,
+                           vals=vals.Numbers()
+                           )  
+        self.add_parameter(name='frequency',
+                           label='Frequency',
+                           unit='Hz',
+                           get_cmd=self._get_frequency,
+                           get_parser=float
+                           ) 
+        self.add_parameter(name='sigout_range',
+                           label='Signal output range',
+                           unit='V',
+                           get_cmd=self._get_sigout_range,
+                           get_parser=float,
+                           set_cmd=self._set_sigout_range,
+                           vals=vals.Enum(0.01, 0.1, 1, 10),
+                           snapshot_get=False
+                           )
+        self.add_parameter(name='sigout_offset',
+                           label='Signal output offset',
+                           unit='V',
+                           get_cmd=self._get_sigout_offset,
+                           get_parser=float,
+                           set_cmd=self._set_sigout_offset,
+                           vals=vals.Numbers(-1, 1),
+                           snapshot_get=False
+                           )
+        self.add_parameter(name='sigout_amplitude',
+                           label='Signal output amplitude',
+                           unit='V',
+                           get_cmd=self._get_sigout_amplitude,
+                           get_parser=float,
+                           set_cmd=self._set_sigout_amplitude,
+                           vals=vals.Numbers(-1, 1),
+                           snapshot_get=False
+                           )
+
+    def _get_phase(self):
+        path = '/{}/demods/{}/phaseshift/'.format(self.dev_id, self.demod)
+        phase = self.daq.getDouble(path)
+        return phase
+
+    def _set_phase(self, phase):
+        path = '/{}/demods/{}/phaseshift/'.format(self.dev_id, self.demod)
+        self.daq.setDouble(path, phase)
+        
+    def _get_gain(self, channel=None):
+        path = '/{}/auxouts/{}/scale/'.format(self.dev_id, self.auxouts[channel])
+        gain = self.daq.getDouble(path)
+        return gain
+
+    def _set_gain(self, gain, channel=None):
+        path = '/{}/auxouts/{}/scale/'.format(self.dev_id, self.auxouts[channel])
+        self.daq.setDouble(path, gain)
+
+    def _get_offset(self, channel=None):
+        path = '/{}/auxouts/{}/offset/'.format(self.dev_id, self.auxouts[channel])
+        gain = self.daq.getDouble(path)
+        return gain
+
+    def _set_offset(self, offset, channel=None):
+        path = '/{}/auxouts/{}/offset/'.format(self.dev_id, self.auxouts[channel])
+        self.daq.setDouble(path, offset)
+
+    def _get_output_value(self, channel=None):
+        path = '/{}/auxouts/{}/value/'.format(self.dev_id, self.auxouts[channel])
+        value = self.daq.getDouble(path)
+        return value
+
+    def _get_output_select(self, channel=None):
+        path = '/{}/auxouts/{}/outputselect/'.format(self.dev_id, self.auxouts[channel])
+        idx = int(self.daq.getDouble(path))
+        output = self.OUTPUT_MAPPING[idx]
+        return output
+
+    def _set_output_select(self, channel=None):
+        path = '/{}/auxouts/{}/outputselect/'.format(self.dev_id, self.auxouts[channel])
+        keys = list(self.OUTPUT_MAPPING.keys())
+        idx = keys[list(self.OUTPUT_MAPPING.values()).index(channel)]
+        self.daq.setInt(path, idx)
+
+    def _get_time_constant(self):
+        path = '/{}/demods/{}/timeconstant/'.format(self.dev_id, self.demod)
+        tc = self.daq.getDouble(path)
+        return tc
+
+    def _set_time_constant(self, tc):
+        path = '/{}/demods/{}/timeconstant/'.format(self.dev_id, self.demod)
+        self.daq.setDouble(path, tc)
+
+    def _get_sigout_range(self):
+        path = '/{}/sigouts/{}/range/'.format(self.dev_id, self.sigout[0])
+        range = self.daq.getDouble(path)
+        return range
+
+    def _set_sigout_range(self, rng):
+        path = '/{}/sigouts/{}/range/'.format(self.dev_id, self.sigout[0])
+        self.daq.setDouble(path, rng)
+
+    def _get_sigout_offset(self):
+        path = '/{}/sigouts/{}/offset/'.format(self.dev_id, self.sigout[0])
+        range = self.daq.getDouble(path)
+        return range
+
+    def _set_sigout_offset(self, offset):
+        path = '/{}/sigouts/{}/offset/'.format(self.dev_id, self.sigout[0])
+        self.daq.setDouble(path, offset)
+
+    def _get_sigout_amplitude(self):
+        path = '/{}/sigouts/{}/amplitudes/{}/'.format(self.dev_id, self.sigout[0], self.sigout[1])
+        range = self.daq.getDouble(path)
+        return range
+
+    def _set_sigout_amplitude(self, amp):
+        path = '/{}/sigouts/{}/amplitudes/{}/'.format(self.dev_id, self.sigout[0], self.sigout[1])
+        self.daq.setDouble(path, amp)
+
+    def _get_frequency(self):
+        path = '/{}/demods/{}/freq/'.format(self.dev_id, self.demod)
+        freq = self.daq.getDouble(path)
+        return freq
+
+    def sample(self):
+        path = '/{}/demods/{}/sample/'.format(self.dev_id, self.demod)
+        return self.daq.getSample(path)

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -70,7 +70,7 @@ class HF2LI(Instrument):
                 name=f'output_{ch}',
                 label=f'{ch} outptut select',
                 get_cmd=lambda channel=ch: self._get_output_select(channel),
-                get_parser=str,
+                get_parser=str
             )
             # Making output select only gettable, since we are
             # explicitly mapping auxouts to X, Y, R, Theta, etc.
@@ -146,90 +146,90 @@ class HF2LI(Instrument):
                 docstring='Multiply by sigout_range to get actual output voltage.'
             )
 
-    def _get_phase(self):
+    def _get_phase(self) -> float:
         path = f'/{self.dev_id}/demods/{self.demod}/phaseshift/'
         return self.daq.getDouble(path)
 
-    def _set_phase(self, phase):
+    def _set_phase(self, phase: float) -> None:
         path = f'/{self.dev_id}/demods/{self.demod}/phaseshift/'
         self.daq.setDouble(path, phase)
         
-    def _get_gain(self, channel):
+    def _get_gain(self, channel: float) -> float:
         path = f'/{self.devid}/auxouts/{self.auxouts[channel]}/scale/'
         return self.daq.getDouble(path)
 
-    def _set_gain(self, gain, channel):
+    def _set_gain(self, gain: float, channel: str) -> None:
         path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/scale/'
         self.daq.setDouble(path, gain)
 
-    def _get_offset(self, channel):
+    def _get_offset(self, channel: str) -> float:
         path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/offset/'
         return self.daq.getDouble(path)
 
-    def _set_offset(self, offset, channel):
+    def _set_offset(self, offset: float, channel: str) -> None:
         path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/offset/'
         self.daq.setDouble(path, offset)
 
-    def _get_output_value(self, channel):
+    def _get_output_value(self, channel: str) -> float:
         path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/value/'
         return self.daq.getDouble(path)
 
-    def _get_output_select(self, channel):
+    def _get_output_select(self, channel: str) -> str:
         path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/outputselect/'
         idx = self.daq.getInt(path)
         return self.OUTPUT_MAPPING[idx]
 
-    def _set_output_select(self, channel):
+    def _set_output_select(self, channel: str) -> None:
         path = f'/{self.dev_id}/auxouts/{self.auxouts[channel]}/outputselect/'
         keys = list(self.OUTPUT_MAPPING.keys())
         idx = keys[list(self.OUTPUT_MAPPING.values()).index(channel)]
         self.daq.setInt(path, idx)
 
-    def _get_time_constant(self):
+    def _get_time_constant(self) -> float:
         path = f'/{self.dev_id}/demods/{self.demod}/timeconstant/'
         return self.daq.getDouble(path)
 
-    def _set_time_constant(self, tc):
+    def _set_time_constant(self, tc: float) -> None:
         path = f'/{self.dev_id}/demods/{self.demod}/timeconstant/'
         self.daq.setDouble(path, tc)
 
-    def _get_sigout_range(self):
+    def _get_sigout_range(self) -> float:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/range/'
         return self.daq.getDouble(path)
 
-    def _set_sigout_range(self, rng):
+    def _set_sigout_range(self, rng: float) -> None:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/range/'
         self.daq.setDouble(path, rng)
 
-    def _get_sigout_offset(self):
+    def _get_sigout_offset(self) -> float:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/offset/'
         return self.daq.getDouble(path)
 
-    def _set_sigout_offset(self, offset):
+    def _set_sigout_offset(self, offset: float) -> None:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/offset/'
         self.daq.setDouble(path, offset)
 
-    def _get_sigout_amplitude(self, mixer_channel):
+    def _get_sigout_amplitude(self, mixer_channel: int) -> float:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/amplitudes/{mixer_channel}/'
         return self.daq.getDouble(path)
 
-    def _set_sigout_amplitude(self, mixer_channel, amp):
+    def _set_sigout_amplitude(self, mixer_channel: int, amp: float) -> None:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/amplitudes/{mixer_channel}/'
         self.daq.setDouble(path, amp)
 
-    def _get_sigout_enable(self, mixer_channel):
+    def _get_sigout_enable(self, mixer_channel: int) -> int:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/enables/{mixer_channel}/'
         return self.daq.getInt(path)
 
-    def _set_sigout_enable(self, mixer_channel, val):
+    def _set_sigout_enable(self, mixer_channel: int, val: int) -> None:
         path = f'/{self.dev_id}/sigouts/{self.sigout}/enables/{mixer_channel}/'
         self.daq.setInt(path, val)
 
-    def _get_frequency(self):
+    def _get_frequency(self) -> float:
         path = f'/{self.dev_id}/demods/{self.demod}/freq/'
         return self.daq.getDouble(path)
 
-    def sample(self):
+    def sample(self) -> dict:
         path = f'/{self.dev_id}/demods/{self.demod}/sample/'
         return self.daq.getSample(path)
         

--- a/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
+++ b/qcodes_contrib_drivers/drivers/ZurichInstruments/HF2LI.py
@@ -71,11 +71,9 @@ class HF2LI(Instrument):
                 label=f'{ch} outptut select',
                 get_cmd=lambda channel=ch: self._get_output_select(channel),
                 get_parser=str,
-                # making this only gettable since we are explicitly mapping
-                # auxouts to X, Y, R, Theta, etc.
-                # set_cmd=lambda output, channel=ch: self._set_output_select(output, channel),
-                # vals=vals.Ints(-1,3)
             )
+            # Making output select only gettable, since we are
+            # explicitly mapping auxouts to X, Y, R, Theta, etc.
             self._set_output_select(ch)
             
         self.add_parameter(


### PR DESCRIPTION
Qcodes drivier for Zurich Instruments HF2LI 50 MHz lock-in amplifier. Requires the zhinst Python API (https://blogs.zhinst.com/schwizer/2011/05/controlling-the-hf2-li-lock-in-with-python/)