### PR TITLE
Dont build contrib driver docs with nitpick

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,8 +88,6 @@ release = version
 # want to store them locally.
 suppress_warnings = ['image.nonlocal_uri']
 
-nitpicky = True
-
 pygments_style = 'sphinx'
 
 numfig = True


### PR DESCRIPTION
As qcodes docs are no longer build with nitpicky.

Fixes https://github.com/QCoDeS/Qcodes_contrib_drivers/issues/70