### PR TITLE
Feature/keithley 2000 scan

### DIFF
--- a/docs/examples/Tektronix_Keithley_6500.ipynb
+++ b/docs/examples/Tektronix_Keithley_6500.ipynb
@@ -40,20 +40,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04475465, firmware:1.0.04b) in 0.06s\n",
+      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04438044, firmware:1.0.04b) in 0.07s\n",
       "Scanner card 2000-SCAN detected.\n"
      ]
     }
    ],
    "source": [
-    "dmm = dmm6500.Keithley_6500('dmm-1','USB0::0x05E6::0x6500::04475465::INSTR')"
+    "dmm = dmm6500.Keithley_6500('dmm-1','TCPIP0::192.168.1.12::inst0::INSTR')"
    ]
   },
   {
@@ -72,16 +72,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "511.8029"
+       "5799.959"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,16 +115,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "511.8136"
+       "5793.865"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +158,7 @@
        "'FRON'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +185,7 @@
        "'REAR'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,16 +210,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "998.4387"
+       "5798.519"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -239,30 +239,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the wrong terminal is active, a warning is printed and NaN is returned:"
+    "If the wrong terminal is active, an error is raised:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Front terminal is active instead of rear terminal.\n"
+     "ename": "RuntimeError",
+     "evalue": "('Front terminal is active instead of rear terminal.', 'getting dmm-1_ch1_resistance')",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-11-7c3ed5015dc0>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mdmm\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mch1\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresistance\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mc:\\users\\frequency conversion\\appdata\\local\\programs\\python\\python38\\lib\\site-packages\\qcodes\\instrument\\parameter.py\u001b[0m in \u001b[0;36mget_wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    583\u001b[0m             \u001b[1;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    584\u001b[0m                 \u001b[0me\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0margs\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0margs\u001b[0m \u001b[1;33m+\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;34m'getting {}'\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 585\u001b[1;33m                 \u001b[1;32mraise\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    586\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    587\u001b[0m         \u001b[1;32mreturn\u001b[0m \u001b[0mget_wrapper\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\users\\frequency conversion\\appdata\\local\\programs\\python\\python38\\lib\\site-packages\\qcodes\\instrument\\parameter.py\u001b[0m in \u001b[0;36mget_wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    570\u001b[0m             \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    571\u001b[0m                 \u001b[1;31m# There might be cases where a .get also has args/kwargs\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 572\u001b[1;33m                 \u001b[0mraw_value\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mget_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    573\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    574\u001b[0m                 \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_from_raw_value_to_value\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mraw_value\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\users\\frequency conversion\\appdata\\local\\programs\\python\\python38\\lib\\site-packages\\qcodes\\utils\\command.py\u001b[0m in \u001b[0;36m__call__\u001b[1;34m(self, *args)\u001b[0m\n\u001b[0;32m    176\u001b[0m             raise TypeError(\n\u001b[0;32m    177\u001b[0m                 'command takes exactly {} args'.format(self.arg_count))\n\u001b[1;32m--> 178\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexec_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mc:\\users\\frequency conversion\\documents\\code\\qcodes_contrib_drivers\\qcodes_contrib_drivers\\drivers\\Tektronix\\Keithley_2000_Scan.py\u001b[0m in \u001b[0;36m_measure\u001b[1;34m(self, quantity)\u001b[0m\n\u001b[0;32m     63\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mask\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"READ?\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     64\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 65\u001b[1;33m             \u001b[1;32mraise\u001b[0m \u001b[0mRuntimeError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Front terminal is active instead of rear terminal.\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mRuntimeError\u001b[0m: ('Front terminal is active instead of rear terminal.', 'getting dmm-1_ch1_resistance')"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "nan"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -271,25 +269,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING: Rear terminal is active instead of front terminal.\n"
+     "ename": "RuntimeError",
+     "evalue": "('Rear terminal is active instead of front terminal.', 'getting dmm-1_resistance')",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-12-84d4b9528614>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mdmm\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresistance\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mc:\\users\\frequency conversion\\appdata\\local\\programs\\python\\python38\\lib\\site-packages\\qcodes\\instrument\\parameter.py\u001b[0m in \u001b[0;36mget_wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    583\u001b[0m             \u001b[1;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    584\u001b[0m                 \u001b[0me\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0margs\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0margs\u001b[0m \u001b[1;33m+\u001b[0m \u001b[1;33m(\u001b[0m\u001b[1;34m'getting {}'\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 585\u001b[1;33m                 \u001b[1;32mraise\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    586\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    587\u001b[0m         \u001b[1;32mreturn\u001b[0m \u001b[0mget_wrapper\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\users\\frequency conversion\\appdata\\local\\programs\\python\\python38\\lib\\site-packages\\qcodes\\instrument\\parameter.py\u001b[0m in \u001b[0;36mget_wrapper\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    570\u001b[0m             \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    571\u001b[0m                 \u001b[1;31m# There might be cases where a .get also has args/kwargs\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 572\u001b[1;33m                 \u001b[0mraw_value\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mget_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    573\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    574\u001b[0m                 \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_from_raw_value_to_value\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mraw_value\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\users\\frequency conversion\\appdata\\local\\programs\\python\\python38\\lib\\site-packages\\qcodes\\utils\\command.py\u001b[0m in \u001b[0;36m__call__\u001b[1;34m(self, *args)\u001b[0m\n\u001b[0;32m    176\u001b[0m             raise TypeError(\n\u001b[0;32m    177\u001b[0m                 'command takes exactly {} args'.format(self.arg_count))\n\u001b[1;32m--> 178\u001b[1;33m         \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mexec_function\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32mc:\\users\\frequency conversion\\documents\\code\\qcodes_contrib_drivers\\qcodes_contrib_drivers\\drivers\\Tektronix\\Keithley_6500.py\u001b[0m in \u001b[0;36m_measure\u001b[1;34m(self, quantity)\u001b[0m\n\u001b[0;32m    152\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mask\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mf\"MEAS:{quantity}?\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    153\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 154\u001b[1;33m             \u001b[1;32mraise\u001b[0m \u001b[0mRuntimeError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Rear terminal is active instead of front terminal.\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mRuntimeError\u001b[0m: ('Rear terminal is active instead of front terminal.', 'getting dmm-1_resistance')"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "nan"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -313,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.2"
   },
   "nbsphinx": {
    "execute": "never"

--- a/docs/examples/Tektronix_Keithley_6500.ipynb
+++ b/docs/examples/Tektronix_Keithley_6500.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,8 +47,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04475465, firmware:1.0.04b) in 0.01s\n",
-      "Scanner card 2000 detected.\n"
+      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04475465, firmware:1.0.04b) in 0.08s\n",
+      "Scanner card 2000-SCAN detected.\n"
      ]
     }
    ],
@@ -72,16 +72,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "511.1986"
+       "511.8841"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,16 +115,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "511.1908"
+       "511.7335"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +158,7 @@
        "'FRON'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +185,7 @@
        "'REAR'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,8 +205,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The 2000-SCAN scanning card allows to measure up to 10 channels via the rear terminal."
+    "The 2000-SCAN scanning card allows to measure up to 10 channels via the rear terminal. To measure e.g. the resistance via channel 1, use:"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "998.4319"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.ch1.resistance.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/Tektronix_Keithley_6500.ipynb
+++ b/docs/examples/Tektronix_Keithley_6500.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,14 +40,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04475465, firmware:1.0.04b) in 0.08s\n",
+      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04475465, firmware:1.0.04b) in 0.06s\n",
       "Scanner card 2000-SCAN detected.\n"
      ]
     }
@@ -72,16 +72,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "511.8841"
+       "511.8029"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,16 +115,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "511.7335"
+       "511.8136"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -158,7 +158,7 @@
        "'FRON'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +185,7 @@
        "'REAR'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,16 +210,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "998.4319"
+       "998.4387"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.ch1.resistance.get()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Checking the active terminal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the wrong terminal is active, a warning is printed and NaN is returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Front terminal is active instead of rear terminal.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "nan"
+      ]
+     },
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -230,10 +271,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Rear terminal is active instead of front terminal.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "nan"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.resistance.get()"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/Tektronix_Keithley_6500.ipynb
+++ b/docs/examples/Tektronix_Keithley_6500.ipynb
@@ -11,12 +11,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Initialization and Connection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The Keithley digital multimeter DMM6500 for the measurement of voltage, current, and resistance, amongst others. The driver implements the measurement of DC voltage and current, as well as the measurement of a resistance via 2- or 4-wire measurement."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,24 +35,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create the instrument (in this case a DMM6500 connected via USB)"
+    "Create the instrument (in this case a DMM6500 connected via USB). If a scanner card is inserted, it will be detected."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04438044, firmware:1.0.04b) in 0.05s\n"
+      "Connected to: KEITHLEY INSTRUMENTS DMM6500 (serial:04475465, firmware:1.0.04b) in 0.01s\n",
+      "Scanner card 2000 detected.\n"
      ]
     }
    ],
    "source": [
-    "dmm = dmm6500.Keithley_6500('dmm-1','USB0::0x05E6::0x6500::04438044::INSTR')"
+    "dmm = dmm6500.Keithley_6500('dmm-1','USB0::0x05E6::0x6500::04475465::INSTR')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performing simple measurements"
    ]
   },
   {
@@ -57,22 +72,140 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2986.62"
+       "511.1986"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "dmm.res.measure.get()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The commands for the different measurable quantities are:\n",
+    "- dmm.res.measure.get(): 2 wire resistance\n",
+    "- dmm.fres.measure.get(): 4 wire resistance\n",
+    "- dmm.volt.measure.get(): DC voltage\n",
+    "- dmm.curr.measure.get(): DC current"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively the measurable quantities can be accessd directly via one of the following commands:\n",
+    "- dmm.resistance.get(): 2 wire resistance\n",
+    "- dmm.resistance_4w.get(): 4 wire resistance\n",
+    "- dmm.voltage_dc.get(): DC voltage\n",
+    "- dmm.current_dc.get(): DC current\n",
+    "For instance, the resistance via a two wire measurement can be measured with the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "511.1908"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.resistance.get()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying the active terminal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The DMM6500 has a front and a rear terminal. The active terminal can only be switched via a knob on the front panel of the multimeter. The currently active terminal can be queried via:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'FRON'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.active_terminal.get()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the rear terminal is active, the same command returns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'REAR'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.active_terminal.get()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the 2000-SCAN scanning card"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 2000-SCAN scanning card allows to measure up to 10 channels via the rear terminal."
    ]
   }
  ],
@@ -92,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.7"
   },
   "nbsphinx": {
    "execute": "never"

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -5,6 +5,9 @@ from .Keithley_6500 import Keithley_6500
 
 
 class Keithley_2000_Scan_Channel(InstrumentChannel):
+    """
+    This is the qcodes driver for a channel of the 2000-SCAN scanner card.
+    """
     def __init__(self, dmm: Keithley_6500, channel: int, **kwargs) -> None:
         """
         Initialize instance of scanner card Keithley 2000-SCAN

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -1,10 +1,18 @@
 from functools import partial
 
 from qcodes.instrument import InstrumentChannel
+from .Keithley_6500 import Keithley_6500
 
 
 class Keithley_2000_Scan_Channel(InstrumentChannel):
-    def __init__(self, dmm, channel: int, **kwargs):
+    def __init__(self, dmm: Keithley_6500, channel: int, **kwargs) -> None:
+        """
+        Initialize instance of scanner card Keithley 2000-SCAN
+        Args:
+            dmm: Instance of digital multimeter Keithley6500 containing the scanner card
+            channel: Channel number
+            **kwargs: Keyword arguments to pass to __init__ function of InstrumentChannel class
+        """
         super().__init__(dmm, f"ch{channel}", **kwargs)
         self.channel = channel
         self.dmm = dmm
@@ -33,9 +41,18 @@ class Keithley_2000_Scan_Channel(InstrumentChannel):
                            get_parser=float,
                            get_cmd=partial(self.measure, 'CURR'))
 
-    def measure(self, measurement_func: str) -> str:
+    def measure(self, quantity: str) -> str:
+        """
+        Measure given quantity at rear terminal of the instrument. Only perform measurement if rear terminal is
+        active. Send SCPI command to measure and read out given quantity.
+        Args:
+            quantity: Quantity to be measured
+
+        Returns: Measurement result
+
+        """
         if self.dmm.active_terminal.get() == 'REAR':
-            self.write(f"SENS:FUNC '{measurement_func}', (@{self.channel:d})")
+            self.write(f"SENS:FUNC '{quantity}', (@{self.channel:d})")
             self.write(f"ROUT:CLOS (@{self.channel:d})")
             return self.ask("READ?")
         else:

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -1,14 +1,17 @@
 from functools import partial
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import InstrumentChannel
-from .Keithley_6500 import Keithley_6500
+
+if TYPE_CHECKING:
+    from .Keithley_6500 import Keithley_6500
 
 
 class Keithley_2000_Scan_Channel(InstrumentChannel):
     """
     This is the qcodes driver for a channel of the 2000-SCAN scanner card.
     """
-    def __init__(self, dmm: Keithley_6500, channel: int, **kwargs) -> None:
+    def __init__(self, dmm: "Keithley_6500", channel: int, **kwargs) -> None:
         """
         Initialize instance of scanner card Keithley 2000-SCAN
         Args:

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -1,0 +1,38 @@
+from functools import partial
+
+from qcodes.instrument import InstrumentChannel
+
+
+class Keithley_2000_Scan_Channel(InstrumentChannel):
+    def __init__(self, dmm, channel: int, **kwargs):
+        super().__init__(dmm, f"ch{channel}", **kwargs)
+        self.channel = channel
+
+        self.add_parameter('resistance',
+                           unit='Ohm',
+                           label=f'Resistance CH{self.channel}',
+                           get_parser=float,
+                           get_cmd=partial(self.measure, 'RES'))
+
+        self.add_parameter('resistance_4w',
+                           unit='Ohm',
+                           label=f'Resistance (4-wire) CH{self.channel}',
+                           get_parser=float,
+                           get_cmd=partial(self.measure, 'FRES'))
+
+        self.add_parameter('voltage_dc',
+                           unit='V',
+                           label=f'DC Voltage CH{self.channel}',
+                           get_parser=float,
+                           get_cmd=partial(self.measure, 'VOLT'))
+
+        self.add_parameter('current_dc',
+                           unit='A',
+                           label=f'DC current CH{self.channel}',
+                           get_parser=float,
+                           get_cmd=partial(self.measure, 'CURR'))
+
+    def measure(self, measurement_func: str) -> str:
+        self.write(f"SENS:FUNC '{measurement_func}', (@{self.channel:d})")
+        self.write(f"ROUT:CLOS (@{self.channel:d})")
+        return self.ask("READ?")

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import TYPE_CHECKING
 
-from qcodes.instrument.channel import InstrumentChannel
+from qcodes.instrument import InstrumentChannel
 
 if TYPE_CHECKING:
     from .Keithley_6500 import Keithley_6500

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -7,6 +7,7 @@ class Keithley_2000_Scan_Channel(InstrumentChannel):
     def __init__(self, dmm, channel: int, **kwargs):
         super().__init__(dmm, f"ch{channel}", **kwargs)
         self.channel = channel
+        self.dmm = dmm
 
         self.add_parameter('resistance',
                            unit='Ohm',
@@ -33,6 +34,10 @@ class Keithley_2000_Scan_Channel(InstrumentChannel):
                            get_cmd=partial(self.measure, 'CURR'))
 
     def measure(self, measurement_func: str) -> str:
-        self.write(f"SENS:FUNC '{measurement_func}', (@{self.channel:d})")
-        self.write(f"ROUT:CLOS (@{self.channel:d})")
-        return self.ask("READ?")
+        if self.dmm.active_terminal.get() == 'REAR':
+            self.write(f"SENS:FUNC '{measurement_func}', (@{self.channel:d})")
+            self.write(f"ROUT:CLOS (@{self.channel:d})")
+            return self.ask("READ?")
+        else:
+            print("WARNING: Front terminal is active instead of rear terminal.")
+            return "nan"

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_2000_Scan.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import TYPE_CHECKING
 
-from qcodes.instrument import InstrumentChannel
+from qcodes.instrument.channel import InstrumentChannel
 
 if TYPE_CHECKING:
     from .Keithley_6500 import Keithley_6500
@@ -27,27 +27,27 @@ class Keithley_2000_Scan_Channel(InstrumentChannel):
                            unit='Ohm',
                            label=f'Resistance CH{self.channel}',
                            get_parser=float,
-                           get_cmd=partial(self.measure, 'RES'))
+                           get_cmd=partial(self._measure, 'RES'))
 
         self.add_parameter('resistance_4w',
                            unit='Ohm',
                            label=f'Resistance (4-wire) CH{self.channel}',
                            get_parser=float,
-                           get_cmd=partial(self.measure, 'FRES'))
+                           get_cmd=partial(self._measure, 'FRES'))
 
         self.add_parameter('voltage_dc',
                            unit='V',
                            label=f'DC Voltage CH{self.channel}',
                            get_parser=float,
-                           get_cmd=partial(self.measure, 'VOLT'))
+                           get_cmd=partial(self._measure, 'VOLT'))
 
         self.add_parameter('current_dc',
                            unit='A',
                            label=f'DC current CH{self.channel}',
                            get_parser=float,
-                           get_cmd=partial(self.measure, 'CURR'))
+                           get_cmd=partial(self._measure, 'CURR'))
 
-    def measure(self, quantity: str) -> str:
+    def _measure(self, quantity: str) -> str:
         """
         Measure given quantity at rear terminal of the instrument. Only perform measurement if rear terminal is
         active. Send SCPI command to measure and read out given quantity.
@@ -62,5 +62,4 @@ class Keithley_2000_Scan_Channel(InstrumentChannel):
             self.write(f"ROUT:CLOS (@{self.channel:d})")
             return self.ask("READ?")
         else:
-            print("WARNING: Front terminal is active instead of rear terminal.")
-            return "nan"
+            raise RuntimeError("Front terminal is active instead of rear terminal.")

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -1,5 +1,5 @@
 from qcodes.instrument.visa import VisaInstrument
-from qcodes.instrument.channel import InstrumentChannel
+from qcodes.instrument import InstrumentChannel
 from qcodes.utils.validators import Numbers
 from functools import partial
 from .Keithley_2000_Scan import Keithley_2000_Scan_Channel

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -26,7 +26,7 @@ class Keithley_Sense(InstrumentChannel):
                            unit=partial(self._get_unit, channel),
                            label=partial(self._get_label, channel),
                            get_parser=float,
-                           get_cmd=partial(self.parent.measure, channel),
+                           get_cmd=partial(self.parent._measure, channel),
                            docstring="Measure value of chosen quantity (Current/Voltage/Resistance)."
                            )
 

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -2,6 +2,7 @@ from qcodes.instrument.visa import VisaInstrument
 from qcodes.instrument import InstrumentChannel
 from qcodes.utils.validators import Numbers
 from functools import partial
+from .Keithley_2000_Scan import Keithley_2000_Scan_Channel
 
 
 class Keithley_Sense(InstrumentChannel):
@@ -96,5 +97,9 @@ class Keithley_6500(VisaInstrument):
         if scan_idn_msg != "Empty Slot":
             msg_parts = scan_idn_msg.split(",")
             print(f"Scanner card {msg_parts[0]}-SCAN detected.")
+            for ch_number in range(1, 11):
+                channel = Keithley_2000_Scan_Channel(self, ch_number)
+                self.add_submodule(f"ch{ch_number:d}", channel)
+
 
 

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -49,8 +49,41 @@ class Keithley_6500(VisaInstrument):
                  **kwargs):
         super().__init__(name, address, terminator=terminator, **kwargs)
 
-        for sense in ['VOLT', 'CURR', 'RES', 'FRES']:
-            channel = Keithley_Sense(self, sense.lower(), sense)
-            self.add_submodule(sense.lower(), channel)
+        for quantity in ['VOLT', 'CURR', 'RES', 'FRES']:
+            channel = Keithley_Sense(self, quantity.lower(), quantity)
+            self.add_submodule(quantity.lower(), channel)
+
+        self.add_parameter('active_terminal',
+                           label='active terminal',
+                           get_cmd="ROUTe:TERMinals?",
+                           docstring="Active terminal of instrument. Can only be switched via knob on front panel.")
+
+        self.add_parameter('resistance',
+                           unit='Ohm',
+                           label='Measured resistance',
+                           get_parser=float,
+                           get_cmd=f"MEAS:RES?"
+                           )
+
+        self.add_parameter('resistance_4w',
+                           unit='Ohm',
+                           label='Measured resistance',
+                           get_parser=float,
+                           get_cmd=f"MEAS:FRES?"
+                           )
+
+        self.add_parameter('volt',
+                           unit='V',
+                           label='Measured DC voltage',
+                           get_parser=float,
+                           get_cmd=f"MEAS:VOLT?"
+                           )
+
+        self.add_parameter('curr',
+                           unit='A',
+                           label='Measured DC current',
+                           get_parser=float,
+                           get_cmd=f"MEAS:CURR?"
+                           )
 
         self.connect_message()

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -98,8 +98,8 @@ class Keithley_6500(VisaInstrument):
             msg_parts = scan_idn_msg.split(",")
             print(f"Scanner card {msg_parts[0]}-SCAN detected.")
             for ch_number in range(1, 11):
-                channel = Keithley_2000_Scan_Channel(self, ch_number)
-                self.add_submodule(f"ch{ch_number:d}", channel)
+                scan_channel = Keithley_2000_Scan_Channel(self, ch_number)
+                self.add_submodule(f"ch{ch_number:d}", scan_channel)
 
     # only measure if front terminal is active
     def measure(self, quantity: str) -> str:

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -6,6 +6,9 @@ from .Keithley_2000_Scan import Keithley_2000_Scan_Channel
 
 
 class Keithley_Sense(InstrumentChannel):
+    """
+    This is the class for a measurement channel, i.e. the quantity to be measured (e.g. resistance, voltage).
+    """
     def __init__(self, parent: VisaInstrument, name: str, quantity: str) -> None:
         """
 
@@ -67,7 +70,9 @@ class Keithley_Sense(InstrumentChannel):
 
 
 class Keithley_6500(VisaInstrument):
-
+    """
+    This is the qcodes driver for a Keithley DMM6500 digital multimeter.
+    """
     def __init__(self, name: str,
                  address: str,
                  terminator="\n",

--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -72,14 +72,14 @@ class Keithley_6500(VisaInstrument):
                            get_cmd=f"MEAS:FRES?"
                            )
 
-        self.add_parameter('volt',
+        self.add_parameter('voltage_dc',
                            unit='V',
                            label='Measured DC voltage',
                            get_parser=float,
                            get_cmd=f"MEAS:VOLT?"
                            )
 
-        self.add_parameter('curr',
+        self.add_parameter('current_dc',
                            unit='A',
                            label='Measured DC current',
                            get_parser=float,
@@ -87,3 +87,14 @@ class Keithley_6500(VisaInstrument):
                            )
 
         self.connect_message()
+
+        # check if scanner card is connected
+        # If no scanner card is connected, the query below returns "Empty Slot".
+        # For the Scanner Card 2000-SCAN used for development of this driver the output was
+        # "2000,10-Chan Mux,0.0.0a,00000000".
+        scan_idn_msg = self.ask(":SYSTem:CARD1:IDN?")
+        if scan_idn_msg != "Empty Slot":
+            msg_parts = scan_idn_msg.split(",")
+            print(f"Scanner card {msg_parts[0]}-SCAN detected.")
+
+


### PR DESCRIPTION
New features:
- added class for Keithley 2000-SCAN card
- added scanning card to Keithely_6500 class
- Keithley 2000-SCAN can be included into other DMM classes if necessary
- Keithley DMM6500: Check if correct terminal is activated
- Keithley DMM6500:  Allow for simpler access of parameters (e.g. `dmm.resistance.get()` instead of `dmm.measure.res.get()`. The latter still works to ensure "downwards" compatibilty.)