### PR TITLE
ITest: fix get function of state parameter

### DIFF
--- a/qcodes_contrib_drivers/drivers/Bilt/ITest.py
+++ b/qcodes_contrib_drivers/drivers/Bilt/ITest.py
@@ -18,7 +18,7 @@ class iTestChannel(InstrumentChannel):
     """
     A single channel of iTest.
     """
-    
+
     def __init__(self, parent: Instrument,
                        name: str,
                        chan_num: int) -> None:
@@ -29,12 +29,12 @@ class iTestChannel(InstrumentChannel):
             chan_num: The number of the channel in question.
         """
         super().__init__(parent, name)
-        
+
         self.chan_num = chan_num
         # Get channel id
         i, c = round(chan_num/4.)+1, chan_num%4
         self.chan_id = 'i{};c{};'.format(i,c)
-        
+
         self.add_parameter('v',
                            label='Channel {} voltage'.format(chan_num),
                            unit='V',
@@ -44,7 +44,7 @@ class iTestChannel(InstrumentChannel):
                            set_cmd=partial(self._parent._set_voltage, chan_num),
                            vals=vals.Numbers(-50, 50)
                            )
-           
+
         self.add_parameter('i',
                            label='Channel {} current'.format(chan_num),
                            unit='A',
@@ -52,7 +52,7 @@ class iTestChannel(InstrumentChannel):
                            get_cmd=partial(self._parent._get_current, chan_num),
                            get_parser=float
                            )
-        
+
         self.add_parameter('ramp_slope',
                            label='Channel {} ramp slope'.format(chan_num),
                            unit='V/ms',
@@ -62,7 +62,7 @@ class iTestChannel(InstrumentChannel):
                            set_cmd=partial(self._parent._set_ramp_slope, chan_num),
                            vals=vals.Numbers(0, 1)
                            )
-        
+
         self.add_parameter('output_mode',
                            label='Channel {} output mode'.format(chan_num),
                            docstring='Mode of the output {exp, ramp}.',
@@ -72,7 +72,7 @@ class iTestChannel(InstrumentChannel):
                            set_parser=str,
                            vals=vals.Enum('ramp', 'exp')
                            )
-        
+
         self.add_parameter('v_range',
                            label = 'Channel {} voltage range'.format(chan_num),
                            docstring='Range of the channel in volt.',
@@ -80,25 +80,26 @@ class iTestChannel(InstrumentChannel):
                            set_parser=float,
                            get_cmd=partial(self._parent._get_chan_range, chan_num),
                            get_parser=float)
-        
+
         self.add_parameter('state',
                            docstring='State of the channel {on, off}.',
                            get_cmd=partial(self._parent._get_chan_state, chan_num),
                            set_cmd=partial(self._parent._set_chan_state, chan_num),
-                           val_mapping=create_on_off_val_mapping(on_val='on', off_val='off'))
-        
+                           val_mapping=create_on_off_val_mapping(on_val='1',
+                                                                 off_val='0'))
+
         self.add_parameter('pos_sat',
                            get_cmd=partial(self._parent._get_chan_pos_sat, chan_num),
                            get_parser=str,
                            set_cmd=partial(self._parent._set_chan_pos_sat, chan_num),
                            set_parser=str,)
-        
+
         self.add_parameter('neg_sat',
                            get_cmd=partial(self._parent._get_chan_neg_sat, chan_num),
                            get_parser=str,
                            set_cmd=partial(self._parent._set_chan_neg_sat, chan_num),
                            set_parser=str,)
-    
+
         self.add_parameter('bilt_name',
                            set_cmd=partial(self._parent._set_chan_name, chan_num),
                            set_parser=str,
@@ -118,7 +119,7 @@ class iTestChannel(InstrumentChannel):
                            get_parser=float,
                            set_cmd=None,
                            vals=vals.Numbers(1e-3, 10),
-                           initial_value=1)
+                           initial_value=1e-3)
 
         self.add_parameter('synchronous_threshold',
                            docstring='Threshold to unblock communication in volt.',
@@ -147,7 +148,7 @@ class iTestChannel(InstrumentChannel):
 class iTestMultiChannelParameter(MultiChannelInstrumentParameter):
     """
     """
-    
+
     def __init__(self, channels, param_name, *args, **kwargs):
         super().__init__(channels, param_name, *args, **kwargs)
 
@@ -156,7 +157,7 @@ class ITest(VisaInstrument):
     """
     This is the QCoDeS python driver for the iTest device from Bilt.
     """
-    
+
     def __init__(self,name:str,
                       address:str,
                       num_chans:int=16,
@@ -167,7 +168,7 @@ class ITest(VisaInstrument):
                       **kwargs: Any) -> None:
         """
         Instantiate the instrument.
-        
+
         Args:
             name: The instrument name used by qcodes
             address: The VISA name of the resource
@@ -181,7 +182,7 @@ class ITest(VisaInstrument):
                 "synchronous_threshold".
             synchronous_delay: Time between to voltage measurement in second.
             synchronous_threshold: Threshold to unblock communication in volt.
-            
+
         Returns:
             ITest object
         """
@@ -189,19 +190,19 @@ class ITest(VisaInstrument):
                                terminator='\n',
                                device_clear=False,
                                **kwargs)
-        
+
         self.idn = self.get_idn()
         self.num_chans = num_chans
         self.chan_range = range(1,self.num_chans+1)
-        
+
         # Create the channels
         channels = ChannelList(parent=self,
                                name='Channels',
                                chan_type=iTestChannel,
                                multichan_paramclass=iTestMultiChannelParameter)
-        
+
         for i in self.chan_range:
-            
+
             channel = iTestChannel(self, name='chan{:02}'.format(i),
                                          chan_num=i)
             channel.synchronous_enable(synchronous_enable)
@@ -209,10 +210,10 @@ class ITest(VisaInstrument):
             channel.synchronous_threshold(synchronous_threshold)
             channels.append(channel)
             self.add_submodule('ch{:02}'.format(i),channel)
-        
+
         channels.lock()
         self.add_submodule('channels',channels)
-        
+
         if init_start:
             for channel in self.channels:
                 channel.v.set(0)
@@ -226,7 +227,7 @@ class ITest(VisaInstrument):
                            v_set:float) -> None:
         """
         Set cmd for the chXX_v parameter
-        
+
         Args:
             chan: The 1-indexed channel number
             v_set: The target voltage
@@ -244,7 +245,7 @@ class ITest(VisaInstrument):
     def _get_voltage(self, chan:int) -> float:
         """
         Get cmd for the chXX_v parameter
-        
+
         Args:
             chan: The 1-indexed channel number
 
@@ -252,14 +253,14 @@ class ITest(VisaInstrument):
             Voltage
         """
         chan_id = self.chan_to_id(chan)
-        
+
         return float(self.ask('{}MEAS:VOLT?'.format(chan_id)))
 
 
     def _get_current(self, chan:int) -> float:
         """
         Get cmd for the chXX_i parameter
-        
+
         Args:
             chan: The 1-indexed channel number
 
@@ -267,7 +268,7 @@ class ITest(VisaInstrument):
             Current
         """
         chan_id = self.chan_to_id(chan)
-        
+
         return float(self.ask('{}MEAS:CURR?'.format(chan_id)))
 
 
@@ -275,7 +276,7 @@ class ITest(VisaInstrument):
                               slope:float) -> None:
         """
         Set slope of chXX for ramp mode
-        
+
         Args:
             chan The 1-indexed channel number
             slope Slope of chXX in V/ms
@@ -287,10 +288,10 @@ class ITest(VisaInstrument):
     def _get_ramp_slope(self, chan:int) -> str:
         """
         Get slope of chXX
-        
+
         Args:
             chan: The 1-indexed channel number
-            
+
         Returns:
             chXX_slope parameter
         """
@@ -302,30 +303,30 @@ class ITest(VisaInstrument):
                                    outf:str) -> None:
         """
         Set how to perform output voltage update
-        
+
         Args:
             chan: The 1-indexed channel number
             ouf: Mode
         """
         chan_id = self.chan_to_id(chan)
-        
+
         if outf=='exp':
             mode = '0'
         elif outf=='ramp':
             mode = '1'
         else:
             raise ValueError('Got unexpected output function mode: {}.'.format(mode))
-        
+
         self.write(chan_id + 'trig:input ' + mode)
 
 
     def _get_output_function(self, chan:int) -> str:
         """
         Get output volage update  function
-        
+
         Args:
             chan: The 1-indexed channel number
-        
+
         Returns:
             mode
         """
@@ -343,7 +344,7 @@ class ITest(VisaInstrument):
                               volt: float) -> None:
         """
         Set output voltage range
-        
+
         Args:
             chan : The 1-indexed channel number
             volt : Voltage range (1.2 or 12)
@@ -355,15 +356,15 @@ class ITest(VisaInstrument):
     def _get_chan_range(self, chan:int) -> str:
         """
         Get output voltage range
-        
+
         Args:
             chan: The 1-indexed channel number
-            
+
         Returns:
             volt: Output voltage range
         """
         chan_id = self.chan_to_id(chan)
-        
+
         return self.ask(chan_id + 'VOLT:RANGE?')[:-2]
 
 
@@ -398,20 +399,18 @@ class ITest(VisaInstrument):
     def _get_chan_state(self, chan:int) -> bool:
         """
         Get channel power state
-        
+
         Args:
             chan: The 1-indexed channel number
-            
+
         Returns:
-            state: Power state 
+            state: Power state
         """
         chan_id = self.chan_to_id(chan)
         state = self.ask(chan_id + 'OUTP ?')
-        
-        if state == '1':
-            return True
-        elif state == '0':
-            return False
+
+        if state in ['1', '0'] :
+            return state
         else:
             raise ValueError('Unknown state output: {}'.format(state))
 
@@ -420,7 +419,7 @@ class ITest(VisaInstrument):
                               state:str) -> None:
         """
         Set channel power state
-        
+
         Args:
             chan: The 1-indexed channel number
             state: power state
@@ -448,7 +447,7 @@ class ITest(VisaInstrument):
         to iX;c;
         Args:
             chan: The 1-indexed channel number
-            
+
         Returns:
             i,c: i=card number, c=channel number of card i
         """

--- a/qcodes_contrib_drivers/drivers/Bilt/ITest.py
+++ b/qcodes_contrib_drivers/drivers/Bilt/ITest.py
@@ -396,7 +396,7 @@ class ITest(VisaInstrument):
         return self.ask(chan_id + 'VOLT:SAT:NEG ?')
 
 
-    def _get_chan_state(self, chan:int) -> bool:
+    def _get_chan_state(self, chan:int) -> str:
         """
         Get channel power state
 


### PR DESCRIPTION
This PR fixes an error in the get function of the state parameter and changes default value of synchronous_delay parameter and delete trailing white spaces.

Previously while getting  the state parameter of a channel (15 for example) by `dac.channels[15].state()`, the following error was raised:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in _from_raw_value_to_value(self, raw_value)
    563                 try:
--> 564                     value = self.inverse_val_mapping[int(value)]
    565                 except (ValueError, KeyError):

KeyError: 0

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
<ipython-input-6-a87cfc1210c9> in <module>
----> 1 dac.channels[15].state()

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in __call__(self, *args, **kwargs)
    397         if len(args) == 0:
    398             if self.gettable:
--> 399                 return self.get()
    400             else:
    401                 raise NotImplementedError('no get cmd found in' +

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in get_wrapper(*args, **kwargs)
    590             except Exception as e:
    591                 e.args = e.args + (f'getting {self}',)
--> 592                 raise e
    593 
    594         return get_wrapper

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in get_wrapper(*args, **kwargs)
    579                 raw_value = get_function(*args, **kwargs)
    580 
--> 581                 value = self._from_raw_value_to_value(raw_value)
    582 
    583                 if self._validate_on_get:

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in _from_raw_value_to_value(self, raw_value)
    564                     value = self.inverse_val_mapping[int(value)]
    565                 except (ValueError, KeyError):
--> 566                     raise KeyError(f"'{value}' not in val_mapping")
    567 
    568         return value

KeyError: ("'False' not in val_mapping", 'getting dac_chan16_state')
```

The PR fixes this.