### PR TITLE
Fix bluefors driver permission error

### DIFF
--- a/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
+++ b/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
@@ -160,6 +160,8 @@ class BlueFors(Instrument):
             return df.iloc[-1]['y']
         except PermissionError:
             return np.nan
+        except OSError:
+            return np.nan
 
 
     def get_pressure(self, channel: int) -> float:
@@ -194,4 +196,6 @@ class BlueFors(Instrument):
 
             return df.iloc[-1]['ch'+str(channel)+'_pressure']
         except PermissionError:
+            return np.nan
+        except OSError:
             return np.nan

--- a/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
+++ b/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
@@ -4,8 +4,11 @@
 import os
 import pandas as pd
 import numpy as np
+import logging
 from datetime import date
 from qcodes.instrument.base import Instrument
+
+log = logging.getLogger(__name__)
 
 class BlueFors(Instrument):
     """
@@ -158,7 +161,8 @@ class BlueFors(Instrument):
             df.index = pd.to_datetime(df['date']+'-'+df['time'], format=' %d-%m-%y-%H:%M:%S')
 
             return df.iloc[-1]['y']
-        except (PermissionError, OSError):
+        except (PermissionError, OSError) as err:
+            log.warning('Cannot access log file: {}. Returning np.nan instead of the temperature value.'.format(err))
             return np.nan
 
 
@@ -193,5 +197,6 @@ class BlueFors(Instrument):
             df.index = pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S')
 
             return df.iloc[-1]['ch'+str(channel)+'_pressure']
-        except (PermissionError, OSError):
+        except (PermissionError, OSError) as err:
+            log.warning('Cannot access log file: {}. Returning np.nan instead of the pressure value.'.format(err))
             return np.nan

--- a/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
+++ b/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
@@ -4,11 +4,8 @@
 import os
 import pandas as pd
 import numpy as np
-import logging
 from datetime import date
 from qcodes.instrument.base import Instrument
-
-log = logging.getLogger(__name__)
 
 class BlueFors(Instrument):
     """
@@ -162,7 +159,10 @@ class BlueFors(Instrument):
 
             return df.iloc[-1]['y']
         except (PermissionError, OSError) as err:
-            log.warning('Cannot access log file: {}. Returning np.nan instead of the temperature value.'.format(err))
+            self.log.warn('Cannot access log file: {}. Returning np.nan instead of the temperature value.'.format(err))
+            return np.nan
+        except IndexError as err:
+            self.log.warn('Cannot parse log file: {}. Returning np.nan instead of the temperature value.'.format(err))
             return np.nan
 
 
@@ -198,5 +198,8 @@ class BlueFors(Instrument):
 
             return df.iloc[-1]['ch'+str(channel)+'_pressure']
         except (PermissionError, OSError) as err:
-            log.warning('Cannot access log file: {}. Returning np.nan instead of the pressure value.'.format(err))
+            self.log.warn('Cannot access log file: {}. Returning np.nan instead of the pressure value.'.format(err))
+            return np.nan
+        except IndexError as err:
+            self.log.warn('Cannot parse log file: {}. Returning np.nan instead of the pressure value.'.format(err))
             return np.nan

--- a/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
+++ b/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
@@ -158,9 +158,7 @@ class BlueFors(Instrument):
             df.index = pd.to_datetime(df['date']+'-'+df['time'], format=' %d-%m-%y-%H:%M:%S')
 
             return df.iloc[-1]['y']
-        except PermissionError:
-            return np.nan
-        except OSError:
+        except (PermissionError, OSError):
             return np.nan
 
 
@@ -195,7 +193,5 @@ class BlueFors(Instrument):
             df.index = pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S')
 
             return df.iloc[-1]['ch'+str(channel)+'_pressure']
-        except PermissionError:
-            return np.nan
-        except OSError:
+        except (PermissionError, OSError):
             return np.nan


### PR DESCRIPTION
This PR fixes an error in reading the log file that could occur if the log file is blocked by another program. This generally arises if the log files are periodically synchronized e.g. with DSynchronize (http://dimio.altervista.org/eng/#DSynchronize).

If the file is not readable at the time of getting the parameter, not a number (nan) is returned.

It fixes the following error:

```
2021-05-25 18:29:24,840 ¦ qcodes.dataset.measurements ¦ WARNING ¦ measurements ¦ __exit__ ¦ 584 ¦ An exception occured in measurement with guid: aaaaaaaa-0000-0000-0000-0179a44ffb4b;
Traceback:
Traceback (most recent call last):
  File "<ipython-input-26-13ac4aa9f5da>", line 14, in <module>
    (bluelagoon.temperature_mixing_chamber, bluelagoon.temperature_mixing_chamber()),
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py", line 399, in __call__
    return self.get()
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py", line 592, in get_wrapper
    raise e
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py", line 579, in get_wrapper
    raw_value = get_function(*args, **kwargs)
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\qcodes\utils\command.py", line 178, in __call__
    return self.exec_function(*args)
  File "c:\users\g-gre-gre058050\qcodes_contrib_drivers\qcodes_contrib_drivers\drivers\BlueFors\BlueFors.py", line 128, in <lambda>
    get_cmd    = lambda: self.get_temperature(channel_mixing_chamber),
  File "c:\users\g-gre-gre058050\qcodes_contrib_drivers\qcodes_contrib_drivers\drivers\BlueFors\BlueFors.py", line 150, in get_temperature
    df = pd.read_csv(file_path,
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\parsers.py", line 610, in read_csv
    return _read(filepath_or_buffer, kwds)
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\parsers.py", line 462, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\parsers.py", line 819, in __init__
    self._engine = self._make_engine(self.engine)
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\parsers.py", line 1050, in _make_engine
    return mapping[engine](self.f, **self.options)  # type: ignore[call-arg]
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\parsers.py", line 1867, in __init__
    self._open_handles(src, kwds)
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\parsers.py", line 1362, in _open_handles
    self.handles = get_handle(
  File "C:\Users\G-GRE-GRE058050\Miniconda3\lib\site-packages\pandas\io\common.py", line 642, in get_handle
    handle = open(
PermissionError: [Errno 13] Permission denied: 'Q:\\bluelagoon\\2021\\20210525_T19S0888_W01_D28\\log\\setup\\21-05-25\\CH6 T 21-05-25.log'

---------------------------------------------------------------------------
PermissionError                           Traceback (most recent call last)
<ipython-input-26-13ac4aa9f5da> in <module>
     12         datasaver.add_result((diff_R, diff_R()),
     13                              (vna.point_s21, vna.point_s21()),
---> 14                              (bluelagoon.temperature_mixing_chamber, bluelagoon.temperature_mixing_chamber()),
     15                              (passed_time, passed_time())
     16                             )

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in __call__(self, *args, **kwargs)
    397         if len(args) == 0:
    398             if self.gettable:
--> 399                 return self.get()
    400             else:
    401                 raise NotImplementedError('no get cmd found in' +

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in get_wrapper(*args, **kwargs)
    590             except Exception as e:
    591                 e.args = e.args + (f'getting {self}',)
--> 592                 raise e
    593 
    594         return get_wrapper

~\Miniconda3\lib\site-packages\qcodes\instrument\parameter.py in get_wrapper(*args, **kwargs)
    577             try:
    578                 # There might be cases where a .get also has args/kwargs
--> 579                 raw_value = get_function(*args, **kwargs)
    580 
    581                 value = self._from_raw_value_to_value(raw_value)

~\Miniconda3\lib\site-packages\qcodes\utils\command.py in __call__(self, *args)
    176             raise TypeError(
    177                 f'command takes exactly {self.arg_count} args')
--> 178         return self.exec_function(*args)

c:\users\g-gre-gre058050\qcodes_contrib_drivers\qcodes_contrib_drivers\drivers\BlueFors\BlueFors.py in <lambda>()
    126                            unit       = 'K',
    127                            get_parser = float,
--> 128                            get_cmd    = lambda: self.get_temperature(channel_mixing_chamber),
    129                            docstring  = 'Temperature of the mixing chamber',
    130                            )

c:\users\g-gre-gre058050\qcodes_contrib_drivers\qcodes_contrib_drivers\drivers\BlueFors\BlueFors.py in get_temperature(self, channel)
    148         file_path = os.path.join(self.folder_path, folder_name, 'CH'+str(channel)+' T '+folder_name+'.log')
    149 
--> 150         df = pd.read_csv(file_path,
    151                             delimiter = ',',
    152                             names     = ['date', 'time', 'y'],

~\Miniconda3\lib\site-packages\pandas\io\parsers.py in read_csv(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, dialect, error_bad_lines, warn_bad_lines, delim_whitespace, low_memory, memory_map, float_precision, storage_options)
    608     kwds.update(kwds_defaults)
    609 
--> 610     return _read(filepath_or_buffer, kwds)
    611 
    612 

~\Miniconda3\lib\site-packages\pandas\io\parsers.py in _read(filepath_or_buffer, kwds)
    460 
    461     # Create the parser.
--> 462     parser = TextFileReader(filepath_or_buffer, **kwds)
    463 
    464     if chunksize or iterator:

~\Miniconda3\lib\site-packages\pandas\io\parsers.py in __init__(self, f, engine, **kwds)
    817             self.options["has_index_names"] = kwds["has_index_names"]
    818 
--> 819         self._engine = self._make_engine(self.engine)
    820 
    821     def close(self):

~\Miniconda3\lib\site-packages\pandas\io\parsers.py in _make_engine(self, engine)
   1048             )
   1049         # error: Too many arguments for "ParserBase"
-> 1050         return mapping[engine](self.f, **self.options)  # type: ignore[call-arg]
   1051 
   1052     def _failover_to_python(self):

~\Miniconda3\lib\site-packages\pandas\io\parsers.py in __init__(self, src, **kwds)
   1865 
   1866         # open handles
-> 1867         self._open_handles(src, kwds)
   1868         assert self.handles is not None
   1869         for key in ("storage_options", "encoding", "memory_map", "compression"):

~\Miniconda3\lib\site-packages\pandas\io\parsers.py in _open_handles(self, src, kwds)
   1360         Let the readers open IOHanldes after they are done with their potential raises.
   1361         """
-> 1362         self.handles = get_handle(
   1363             src,
   1364             "r",

~\Miniconda3\lib\site-packages\pandas\io\common.py in get_handle(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)
    640                 errors = "replace"
    641             # Encoding
--> 642             handle = open(
    643                 handle,
    644                 ioargs.mode,

PermissionError: [Errno 13] Permission denied: 'Q:\\bluelagoon\\2021\\20210525_T19S0888_W01_D28\\log\\setup\\21-05-25\\CH6 T 21-05-25.log'
```