### PR TITLE
Add channel name to labels in Vaunix LDA

### DIFF
--- a/qcodes_contrib_drivers/drivers/Vaunix/LDA.py
+++ b/qcodes_contrib_drivers/drivers/Vaunix/LDA.py
@@ -290,11 +290,17 @@ class LdaWorkingFrequency(LdaParameter):
             instrument: parent instrument, either LDA or LDA channel
         """
         dll = instrument.root_instrument.dll
+
+        label = "Working frequency"
+        if isinstance(instrument, LdaChannel):
+            # prefix label to make channels more easily distinguishable in plots
+            label = f"{instrument.short_name} {label}"
+
         super().__init__(name, instrument,
                          dll_get_function=dll.fnLDA_GetWorkingFrequency,
                          dll_set_function=dll.fnLDA_SetWorkingFrequency,
                          unit="Hz",
-                         label="Working frequency",
+                         label=label,
                          docstring="Frequency at which the "
                                    "attenuation is most accurate.",
                          **kwargs

--- a/qcodes_contrib_drivers/drivers/Vaunix/LDA.py
+++ b/qcodes_contrib_drivers/drivers/Vaunix/LDA.py
@@ -258,12 +258,17 @@ class LdaAttenuation(LdaParameter):
         max_att = dll.fnLDA_GetMaxAttenuationHR(ref) * self.scaling
         vals = Numbers(min_att, max_att)
 
+        label = "Attenuation"
+        if isinstance(instrument, LdaChannel):
+            # prefix label to make channels more easily distinguishable in plots
+            label = f"{instrument.short_name} {label}"
+
         super().__init__(name, instrument,
                          dll_get_function=dll.fnLDA_GetAttenuationHR,
                          dll_set_function=dll.fnLDA_SetAttenuationHR,
                          vals=vals,
                          unit="dB",
-                         label="Attenuation",
+                         label=label,
                          **kwargs,
                          )
 


### PR DESCRIPTION
This PR adds labels like "ch1 Attenuation" instead of just "Attenuation" when doing attenuation sweeps with a Vaunix LDA with multiple channels.