### PR TITLE
Update M5180.py

### DIFF
--- a/qcodes_contrib_drivers/drivers/CopperMountain/M5180.py
+++ b/qcodes_contrib_drivers/drivers/CopperMountain/M5180.py
@@ -167,7 +167,7 @@ class PointMagPhase(MultiParameter):
         Returns:
             Tuple[ParamRawDataType, ...]: magnitude, phase
         """
-        assert isinstance(self.instrument, M5180)
+
         self.instrument.write('CALC1:PAR:COUN 1') # 1 trace
         self.instrument.write('CALC1:PAR1:DEF {}'.format(self.name[-3:]))
         self.instrument.write('CALC1:TRAC1:FORM SMITH')  # Trace format


### PR DESCRIPTION
"assert isinstance(self.instrument, M5180)"
I received some error from this line.
Is it because I am using S5045 instead of M5180?

There must be a better way to code so that this driver can accommodate all the CopperMountain VNAs.
I am not good enough to do it but if some one can tell me how to do, I will try to work on it.