### PR TITLE
AFG3000: use PermissiveMultiples until MultiType can AND

### DIFF
--- a/qcodes_contrib_drivers/drivers/Tektronix/AFG3000.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/AFG3000.py
@@ -59,7 +59,7 @@ class AFG3000(VisaInstrument):
                 get_cmd=f'SOURce{src}:AM:DEPTh?',
                 get_parser=float,
                 set_cmd=f'SOURce{src}:AM:DEPTh {{}}PCT',
-                vals=vals.Multiples(divisor=0.1, min_value=0, max_value=120)
+                vals=vals.PermissiveMultiples(divisor=0.1)  # TODO min_value=0, max_value=120
             )
 
             # Frequency modulation
@@ -104,7 +104,7 @@ class AFG3000(VisaInstrument):
                     get_cmd=f'SOURce{src}:{mod_type}:INTernal:FREQuency?',
                     get_parser=float,
                     set_cmd=f'SOURce{src}:{mod_type}:INTernal:FREQuency {{}}Hz',
-                    vals=vals.Multiples(divisor=1e-3, min_value=2e-3, max_value=5e4)
+                    vals=vals.PermissiveMultiples(divisor=1e-3)  # TODO min_value=2e-3, max_value=5e4
                 )              
                 self.add_parameter(
                     name=f'{mod_type.lower()}_internal_function{src}',


### PR DESCRIPTION
Temp fix for https://github.com/QCoDeS/Qcodes_contrib_drivers/issues/115
May pass incorrect min/max values.
