### PR TITLE
Add typing to afg3000 driver

### DIFF
--- a/qcodes_contrib_drivers/drivers/Tektronix/AFG3000.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/AFG3000.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Tuple
 log = logging.getLogger(__name__)
 
 from qcodes import VisaInstrument
@@ -9,7 +10,8 @@ class AFG3000(VisaInstrument):
     
     Not all instrument functionality is included here.
     """
-    def __init__(self, name, address, **kwargs):
+
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address, terminator='\n', timeout=20, **kwargs)
 
         self.add_parameter(
@@ -186,7 +188,14 @@ class AFG3000(VisaInstrument):
             )
 
             if src == 1:
-                combine_enum = ('NOISe', 'NOIS', 'EXTernal', 'EXT', 'BOTH', '')
+                combine_enum: Tuple[str, ...] = (
+                    "NOISe",
+                    "NOIS",
+                    "EXTernal",
+                    "EXT",
+                    "BOTH",
+                    "",
+                )
             else:
                 combine_enum = ('NOISe', 'NOIS', '')
             self.add_parameter(
@@ -580,24 +589,24 @@ class AFG3000(VisaInstrument):
         self.snapshot(update=True)
         self.connect_message()
 
-    def self_calibrate(self):
+    def self_calibrate(self) -> None:
         self.write('CALibration:ALL')
         self.wait()
 
-    def self_test(self):
+    def self_test(self) -> None:
         self.write('DIAGnostic:ALL')
         self.wait()
 
-    def abort(self):
+    def abort(self) -> None:
         self.write('ABORt')
         self.wait()
 
-    def reset(self):
+    def reset(self) -> None:
         log.info(f'Resetting {self.name}.')
         self.write('*RST')
         self.wait()
 
-    def wait(self):
+    def wait(self) -> None:
         self.write('*WAI')
 
     def save(self, location: int) -> None:

--- a/qcodes_contrib_drivers/drivers/Tektronix/AFG3000.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/AFG3000.py
@@ -1,6 +1,4 @@
-import logging
 from typing import Any, Tuple
-log = logging.getLogger(__name__)
 
 from qcodes import VisaInstrument
 import qcodes.utils.validators as vals
@@ -602,7 +600,7 @@ class AFG3000(VisaInstrument):
         self.wait()
 
     def reset(self) -> None:
-        log.info(f'Resetting {self.name}.')
+        self.log.info(f'Resetting {self.name}.')
         self.write('*RST')
         self.wait()
 
@@ -612,17 +610,17 @@ class AFG3000(VisaInstrument):
     def save(self, location: int) -> None:
         if location not in [0, 1, 2, 3, 4]:
             raise ValueError(f'Location must be in {[0, 1, 2, 3, 4]}.')
-        log.info(f'Instrument settings saved to location {location}.')
+        self.log.info(f'Instrument settings saved to location {location}.')
         self.write(f'*SAVE {location}')
 
     def recall(self, location: int) -> None:
         if location not in [0, 1, 2, 3, 4]:
             raise ValueError(f'Location must be in {[0, 1, 2, 3, 4]}.')
-        log.info(f'Recalling instrument settings from location {location}.')
+        self.log.info(f'Recalling instrument settings from location {location}.')
         self.write(f'*RCL {location}')
 
     def synchronize_phase(self, src: int) -> None:
-        log.info('Synchronizing CH1 and CH2 phase.')
+        self.log.info('Synchronizing CH1 and CH2 phase.')
         self.write(f'SOURce{src}:PHASe:INITiate')
 
 class AFG3252(AFG3000):


### PR DESCRIPTION
This would have caught the incorrect validator usage from https://github.com/QCoDeS/Qcodes_contrib_drivers/issues/115

Also rewrite the driver to use the log attached to the instrument already