### PR TITLE
QDevil: Correct typo in init file

### DIFF
--- a/qcodes_contrib_drivers/drivers/QDevil/QDAC2.py
+++ b/qcodes_contrib_drivers/drivers/QDevil/QDAC2.py
@@ -1939,7 +1939,7 @@ class QDac2(VisaInstrument):
         return int(self.ask('syst:err:coun?'))
 
     def start_all(self) -> None:
-        """Trigger the global SCPI bus (*TRG)
+        """Trigger the global SCPI bus (``*TRG``)
 
         All generators, that have not been explicitly set to trigger on an
         internal or external trigger, will be started.


### PR DESCRIPTION
@jpsecher 

* Python files are only packaged if you include a `__init__.py` file in the folder not a `__init_.py` file 
* Do you want the yaml files to be part of the package or Are they only indended to be there for running tests from source.

If you want to include the files then then should be included as pacakge data in setup.cfg
Compare https://github.com/QCoDeS/Qcodes_contrib_drivers/blob/master/setup.cfg to 
https://github.com/QCoDeS/Qcodes/blob/master/setup.cfg#L55
