### PR TITLE
Analog modulation for NI RFSG driver

### DIFF
--- a/docs/examples/NationalInstruments_RFSG.ipynb
+++ b/docs/examples/NationalInstruments_RFSG.ipynb
@@ -134,8 +134,139 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analog (amplitude / phase / frequency) modulation\n",
+    "\n",
+    "In this example, we show amplitude modulation (AM). You should connect a modulation signal (for example from an other RF source or an AWG) to the AM IN port on the front of the device for this to work.\n",
+    "\n",
+    "With analog modulation disabled, the unmodulated carrier signal output by the MW source is $A_c \\cos(2\\pi f t)$. If you connect a modulation signal $m(t)$ to the AM IN port, the output signal will nominally be\n",
+    "\n",
+    "$$\n",
+    "(m(t) + A_c)\\cos(2\\pi f t).\n",
+    "$$\n",
+    "\n",
+    "Note that connecting a 0V signal to the modulation port produces a continuous tone at the base amplitude $A_c$. In order to suppress the carrier wave, you need to send a negative voltage to the AM IN port."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'none'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pxie5654.analog_mod_type()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# turn on signal generation\n",
+    "pxie5654.output_enabled(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Enable amplitude modulation. After running the cell below, the amplitude of the signal should be modulated by the signal sent to AM IN."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pxie5654.analog_mod_type(\"AM\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The AM sensitivity can be adjusted with the `amplitude_mod_sensitivity` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100.0"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pxie5654.amplitude_mod_sensitivity()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pxie5654.amplitude_mod_sensitivity(50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pxie5654.amplitude_mod_sensitivity(100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Turn off analog modulation and revert to normal continuous signal generation with a constant amplitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pxie5654.analog_mod_type(\"none\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stop RF generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
@@ -5,7 +5,7 @@ from functools import partial
 from qcodes.utils.helpers import create_on_off_val_mapping as on_off_map
 
 from .visa_types import (
-        ViString, ViAttr, ViSession, ViReal64, ViBoolean
+        ViString, ViAttr, ViSession, ViReal64, ViBoolean, ViInt32,
         )
 from .dll_wrapper import AttributeWrapper, NamedArgType
 from .ni_dll_instrument import NIDLLInstrument
@@ -22,9 +22,23 @@ NIRFSG_ATTR_FREQUENCY                    = AttributeWrapper(ViAttr(1250001), ViR
 NIRFSG_ATTR_POWER_LEVEL                  = AttributeWrapper(ViAttr(1250002), ViReal64)
 NIRFSG_ATTR_OUTPUT_ENABLED               = AttributeWrapper(ViAttr(1250004), ViBoolean)
 NIRFSG_ATTR_REF_CLOCK_SOURCE             = AttributeWrapper(ViAttr(1150001), ViString)
+NIRFSG_ATTR_ANALOG_MODULATION_TYPE       = AttributeWrapper(ViAttr(1150032), ViInt32)
 NIRFSG_ATTR_PULSE_MODULATION_ENABLED     = AttributeWrapper(ViAttr(1250051), ViBoolean)
 
 logger = logging.getLogger(__name__)
+
+
+# Name mapping for analog modulation mode.
+# These can be found in the NI RFSG header file, found by default in
+# C:\Program Files (x86)\IVI Foundation\IVI\Include\niRFSG.h
+# or in the online documentation: https://zone.ni.com/reference/en-XX/help/371025V-01/rfsgproperties/pnirfsg_anlgmod.type/
+ANALOG_MOD_NAME_MAP = {
+    "none": 0, # NIRFSG_VAL_NONE
+    "FM": 2000, # NIRFSG_VAL_FM
+    "PM": 2001, # NIRFSG_VAL_PM
+    "AM": 2002, # NIRFSG_VAL_AM
+}
+
 
 CLK_SRC_MAP = {
     "onboard": "OnboardClock",
@@ -133,6 +147,19 @@ class NationalInstruments_RFSG(NIDLLInstrument):
                                            ),
                            val_mapping=on_off_map(on_val=True, off_val=False),
                            initial_value=False,
+                           )
+
+        self.add_parameter(name="analog_mod_type",
+                           label="Analog modulation type",
+                           docstring="Specifies the analog modulation format "
+                                     "to use. FM = frequency modulation, PM = "
+                                     "pulse modulation, AM = amplitude "
+                                     "modulation.",
+                           get_cmd=partial(self.get_attribute,
+                                           NIRFSG_ATTR_ANALOG_MODULATION_TYPE),
+                           set_cmd=partial(self.set_attribute,
+                                           NIRFSG_ATTR_ANALOG_MODULATION_TYPE),
+                           val_mapping=ANALOG_MOD_NAME_MAP,
                            )
 
         self.add_parameter(name="clock_source",

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
@@ -3,6 +3,7 @@ from typing import Optional
 from functools import partial
 
 from qcodes.utils.helpers import create_on_off_val_mapping as on_off_map
+from qcodes.utils.validators import Numbers
 
 from .visa_types import (
         ViString, ViAttr, ViSession, ViReal64, ViBoolean, ViInt32,
@@ -23,6 +24,7 @@ NIRFSG_ATTR_POWER_LEVEL                  = AttributeWrapper(ViAttr(1250002), ViR
 NIRFSG_ATTR_OUTPUT_ENABLED               = AttributeWrapper(ViAttr(1250004), ViBoolean)
 NIRFSG_ATTR_REF_CLOCK_SOURCE             = AttributeWrapper(ViAttr(1150001), ViString)
 NIRFSG_ATTR_ANALOG_MODULATION_TYPE       = AttributeWrapper(ViAttr(1150032), ViInt32)
+NIRFSG_ATTR_ANALOG_MODULATION_AM_SENSITIVITY = AttributeWrapper(ViAttr(1150167), ViReal64)
 NIRFSG_ATTR_PULSE_MODULATION_ENABLED     = AttributeWrapper(ViAttr(1250051), ViBoolean)
 
 logger = logging.getLogger(__name__)
@@ -160,6 +162,23 @@ class NationalInstruments_RFSG(NIDLLInstrument):
                            set_cmd=partial(self.set_attribute,
                                            NIRFSG_ATTR_ANALOG_MODULATION_TYPE),
                            val_mapping=ANALOG_MOD_NAME_MAP,
+                           )
+
+        self.add_parameter(name="amplitude_mod_sensitivity",
+                           label="Amplitude modulation sensitivity",
+                           docstring="The modulation signal sent to AM IN is "
+                                     "scaled by this percentage before "
+                                     "multiplying the carrier wave.",
+                           unit="%/V",
+                           get_cmd=partial(
+                                self.get_attribute,
+                                NIRFSG_ATTR_ANALOG_MODULATION_AM_SENSITIVITY
+                           ),
+                           set_cmd=partial(
+                                self.set_attribute,
+                                NIRFSG_ATTR_ANALOG_MODULATION_AM_SENSITIVITY
+                           ),
+                           vals=Numbers(0, 100),
                            )
 
         self.add_parameter(name="clock_source",

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
@@ -155,8 +155,9 @@ class NationalInstruments_RFSG(NIDLLInstrument):
                            label="Analog modulation type",
                            docstring="Specifies the analog modulation format "
                                      "to use. FM = frequency modulation, PM = "
-                                     "pulse modulation, AM = amplitude "
-                                     "modulation.",
+                                     "phase modulation, AM = amplitude "
+                                     "modulation. Set to 'none' to disable "
+                                     "analog modulation.",
                            get_cmd=partial(self.get_attribute,
                                            NIRFSG_ATTR_ANALOG_MODULATION_TYPE),
                            set_cmd=partial(self.set_attribute,

--- a/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
+++ b/qcodes_contrib_drivers/drivers/NationalInstruments/RFSG.py
@@ -10,7 +10,8 @@ from .visa_types import (
 from .dll_wrapper import AttributeWrapper, NamedArgType
 from .ni_dll_instrument import NIDLLInstrument
 
-# constants used for querying attributes
+# Constants used for querying attributes.
+# These can be found in the RFSG C API documentation, see below.
 NIRFSG_ATTR_INSTRUMENT_FIRMWARE_REVISION = AttributeWrapper(ViAttr(1050510), ViString)
 NIRFSG_ATTR_INSTRUMENT_MANUFACTURER      = AttributeWrapper(ViAttr(1050511), ViString)
 NIRFSG_ATTR_INSTRUMENT_MODEL             = AttributeWrapper(ViAttr(1050512), ViString)


### PR DESCRIPTION
Add functionality to enable analog (amplitude / frequency / phase) modulation for NI-RFSG based devices. Includes example code in the example notebook. Tested amplitude modulation with a PXIe-5654.