### PR TITLE
Mypy better missing imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = 'setuptools.build_meta'
 [tool.mypy]
 strict_optional = true
 disallow_untyped_decorators = true
-ignore_missing_imports = true
+ignore_missing_imports = false
 show_column_numbers = true
 warn_unused_ignores = true
 warn_unused_configs = true
@@ -21,6 +21,23 @@ module = [
     "qcodes_contrib_drivers.drivers.Spectrum.pyspcm"
     ]
 ignore_errors = true
+
+# these are packages that we import
+# but either don't have stubs or we
+# dont have them installed.
+[[tool.mypy.overrides]]
+module = [
+    "cffi",
+    "keysightSD1",
+    "nidaqmx.*",
+    "niswitch.*",
+    "pandas",
+    "py_header.*",
+    "pyspcm",
+    "spirack",
+    "zhinst.*"
+]
+ignore_missing_imports = true
 
 [tool.versioningit]
 default-version = "0.0"

--- a/qcodes_contrib_drivers/tests/test_Keysight_M3201A.py
+++ b/qcodes_contrib_drivers/tests/test_Keysight_M3201A.py
@@ -2,17 +2,17 @@ from qcodes.instrument_drivers.test import DriverTestCase
 import unittest
 
 try:
-    from qcodes.instrument_drivers.Keysight.M3201A import Keysight_M3201A
+    from qcodes_contrib_drivers.drivers.Keysight.Keysight_M3201A import Keysight_M3201A
     Keysight_M3201A_found = True
 except ImportError:
     Keysight_M3201A_found = False
 try:
-    from qcodes.instrument_drivers.Keysight.M3300A import M3300A_AWG
+    from qcodes_contrib_drivers.drivers.Keysight.Keysight_M3300A import M3300A_AWG
     M3300A_AWG_found = True
 except ImportError:
     M3300A_AWG_found = False
 try:
-    from qcodes.instrument_drivers.Keysight.SD_common.SD_Module import SD_Module
+    from qcodes_contrib_drivers.drivers.Keysight.SD_common.SD_Module import SD_Module
     SD_Module_found = True
 except ImportError:
     SD_Module_found = False


### PR DESCRIPTION
This means that mypy will only skip missing imports for modules that we have explicitly marked as known to be missing or non typed. This also found a bug in a test file. These tests dont run automatically since they require the instrument being present