### PR TITLE
Fix Keithley6500 driver

### DIFF
--- a/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
+++ b/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6500.py
@@ -23,8 +23,8 @@ class Keithley_Sense(InstrumentChannel):
         super().__init__(parent, name)
 
         self.add_parameter('measure',
-                           unit=partial(self._get_unit, channel),
-                           label=partial(self._get_label, channel),
+                           unit=self._get_unit(channel),
+                           label=self._get_label(channel),
                            get_parser=float,
                            get_cmd=partial(self.parent._measure, channel),
                            docstring="Measure value of chosen quantity (Current/Voltage/Resistance/Temperature)."


### PR DESCRIPTION
The `Keithley_Sense` submodule defined the `label` and `unit` of the `measure` parameter incorrect. We have to set them as a string, not as a method.