### PR TITLE
Fix marker period start mnemonic

### DIFF
--- a/qcodes_contrib_drivers/drivers/QDevil/QDAC2.py
+++ b/qcodes_contrib_drivers/drivers/QDevil/QDAC2.py
@@ -526,7 +526,7 @@ class _Waveform_Context(_Channel_Context):
     def _period_start_marker(self, wave_kind: str) -> QDac2Trigger_Context:
         if not self._marker_period_start:
             self._marker_period_start = self.allocate_trigger()
-        self._write_channel(f'sour{"{0}"}:{wave_kind}:mark:pst {self._marker_period_start.value}')
+        self._write_channel(f'sour{"{0}"}:{wave_kind}:mark:pstart {self._marker_period_start.value}')
         return self._marker_period_start
 
     def _make_ready_to_start(self, wave_kind: str) -> None:


### PR DESCRIPTION
While the QDAC II manual states "PST" as the abbreviated mnemonic, when using this command the QDAC raises an error with unknown mnemonic. Using the unabbreviated form works.

I haven't seen this issue for other commands, but have not checked thoroughly.

N.B. I am using firmware version 7-0.17.5