### PR TITLE
Switch publish to official pypi action

### DIFF
--- a/.github/workflows/upload_to_pypi.yaml
+++ b/.github/workflows/upload_to_pypi.yaml
@@ -9,7 +9,8 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3.5.2
     - name: Set up Python
@@ -23,9 +24,6 @@ jobs:
         python -m build
     - name: Install Twine
       run: pip install twine
-    - name: Publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload dist/*
+    - name: Publish to pypi
+      uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
using the trusted flow at https://docs.pypi.org/trusted-publishers/