### PR TITLE
Fix typechecking with pandas stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",]
 requires-python = ">=3.9"
-dependencies = [ "qcodes>=0.37.0", "versioningit>=2.0.1", "packaging"]
+dependencies = [ "qcodes>=0.37.0", "versioningit>=2.0.1", "packaging", "pandas"]
 dynamic = [ "version",]
 
 [[project.maintainers]]
@@ -47,7 +47,8 @@ test = [
     "pytest-cov>=3.0.0",
     "coverage[toml]>=6.2",
     "pyvisa-sim",
-    "types-tqdm>=4.64.6"
+    "types-tqdm>=4.64.6",
+    "pandas-stubs",
 ]
 docs = [ "sphinx", "sphinx_rtd_theme", "nbsphinx", ]
 

--- a/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
+++ b/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
@@ -167,6 +167,7 @@ class BlueFors(Instrument):
                 )
             df["date_time"] = date_time
             df.set_index("date_time", inplace=True)
+            df.sort_index(inplace=True)
             return df.iloc[-1]["y"]
         except (PermissionError, OSError) as err:
             self.log.warn('Cannot access log file: {}. Returning np.nan instead of the temperature value.'.format(err))
@@ -206,6 +207,7 @@ class BlueFors(Instrument):
 
             df["date_time"] = pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S')
             df.set_index("date_time", inplace=True)
+            df.sort_index(inplace=True)
 
             return df.iloc[-1]['ch'+str(channel)+'_pressure']
         except (PermissionError, OSError) as err:

--- a/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
+++ b/qcodes_contrib_drivers/drivers/BlueFors/BlueFors.py
@@ -157,12 +157,17 @@ class BlueFors(Instrument):
 
             try:
                 # There is a space before the day for old BlueFors Control Sofware versions
-                df.index = pd.to_datetime(df['date']+'-'+df['time'], format=' %d-%m-%y-%H:%M:%S')
-            except:
+                date_time = pd.to_datetime(
+                    df["date"] + "-" + df["time"], format=" %d-%m-%y-%H:%M:%S"
+                )
+            except Exception:
                 # There is no space before the day with BlueFors Control Software v2.2
-                df.index = pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S')
-
-            return df.iloc[-1]['y']
+                date_time = pd.to_datetime(
+                    df["date"] + "-" + df["time"], format="%d-%m-%y-%H:%M:%S"
+                )
+            df["date_time"] = date_time
+            df.set_index("date_time", inplace=True)
+            return df.iloc[-1]["y"]
         except (PermissionError, OSError) as err:
             self.log.warn('Cannot access log file: {}. Returning np.nan instead of the temperature value.'.format(err))
             return np.nan
@@ -199,7 +204,8 @@ class BlueFors(Instrument):
                                     'void'],
                             header=None)
 
-            df.index = pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S')
+            df["date_time"] = pd.to_datetime(df['date']+'-'+df['time'], format='%d-%m-%y-%H:%M:%S')
+            df.set_index("date_time", inplace=True)
 
             return df.iloc[-1]['ch'+str(channel)+'_pressure']
         except (PermissionError, OSError) as err:


### PR DESCRIPTION
Blueforce drivers depends on pandas but this was never added as a dependency.

Add pandas and pandas stubs as dependencies and fix issues with type checking against pandas stubs.