### PR TITLE
Keithley 6430: Add appropriate lower limit for voltage compliance

### DIFF
--- a/src/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6430.py
+++ b/src/qcodes_contrib_drivers/drivers/Tektronix/Keithley_6430.py
@@ -46,7 +46,7 @@ class Keithley_6430(VisaInstrument):
                            get_parser=float,
                            set_cmd='SENS:VOLT:PROT {}',
                            get_cmd='SENS:VOLT:PROT?',
-                           vals=Numbers(1e-12, 210)
+                           vals=Numbers(0.2e-3, 210),
                            )
         self.add_parameter('source_current_compliance_tripped',
                            get_cmd='SENS:CURR:PROT:TRIP?',


### PR DESCRIPTION
Hi!

We noticed a bug in this SMU driver: writing an SCPI command to set a voltage compliance value that is below the minimum accepted by the device (0.2 mV) will cause the value to be silently ignored, and the previous compliance level will stay. Without this modification, it is possible to set the compliance to 0.1 mV in QCoDeS but accidentally pass 20 V, since that is the default voltage compliance when the device is booted. This PR fixes this behavior.