### PR TITLE
move versioningit config to pyprojec.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 68.1.2",
-    "versioningit >= 2.0.1"
+    "versioningit >= 2.2.1"
 ]
 build-backend = 'setuptools.build_meta'
 
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",]
 requires-python = ">=3.9"
-dependencies = [ "qcodes>=0.42.0", "versioningit>=2.0.1", "packaging", "pandas"]
+dependencies = [ "qcodes>=0.42.0", "versioningit>=2.2.1", "packaging", "pandas"]
 dynamic = [ "version",]
 
 [[project.maintainers]]
@@ -94,6 +94,10 @@ license-files = [
     "LICENSE_TEKTRONIX_AWG520_KEITHLEY_2700",
     "LICENSE",
 ]
+
+[tool.setuptools.cmdclass]
+sdist = "versioningit.cmdclass.sdist"
+build_py = "versioningit.cmdclass.build_py"
 
 [tool.versioningit]
 default-version = "0.0"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,8 @@
-import setuptools
+"""
+This file only exists as a fallback for older versions of pip/setuptools
+All configuration is done in pyproject.toml
+"""
 from setuptools import setup
-from versioningit import get_cmdclasses
-
-# this file does not contain configuration
-# all config should be in pyproject.toml
-
-
-if int(setuptools.__version__.split(".")[0]) < 61:
-    raise RuntimeError(
-        "At least setuptools 61 is required to install qcodes-contrib-drivers from source"
-    )
-
-try:
-    import pip
-
-    if int(pip.__version__.split(".")[0]) < 19:
-        raise RuntimeError("At least pip 19 is required to install qcodes-contrib-drivers from source")
-except ImportError:
-    # we are not being executed from pip so pip version is not important
-    pass
 
 if __name__ == "__main__":
-    setup(
-        cmdclass=get_cmdclasses(),
-    )
+    setup()


### PR DESCRIPTION
This has been possible since version 2.2 so bump
min version accordingly.

Remove warnings for older pip versions since the relevant versions are now 6 years old