### PR TITLE
add missing dependency on cffi for Advantech driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",]
 requires-python = ">=3.9"
-dependencies = [ "qcodes>=0.42.0", "versioningit>=2.2.1", "packaging", "pandas"]
+dependencies = [ "qcodes>=0.42.0", "versioningit>=2.2.1", "packaging", "pandas", "cffi"]
 dynamic = [ "version",]
 
 [[project.maintainers]]


### PR DESCRIPTION
This used to be an transitive dependency of qcodes but that changed when qcodes dropped opencensus install