### PR TITLE
pass metadata/label as kwarg

### DIFF
--- a/src/qcodes_contrib_drivers/drivers/Horiba/Horiba_FHR.py
+++ b/src/qcodes_contrib_drivers/drivers/Horiba/Horiba_FHR.py
@@ -398,7 +398,7 @@ class HoribaFHR(Instrument):
             )
         }
 
-        super().__init__(name, additional_metadata | dict(metadata or {}), label)
+        super().__init__(name, metadata=additional_metadata | dict(metadata or {}), label=label)
 
         gratings = ChannelList(self, 'gratings', GratingChannel)
         slits = ChannelList(self, 'slits', SlitChannel)


### PR DESCRIPTION
To prepare for support of https://github.com/microsoft/Qcodes/pull/6012 where these args become kwargs only. 