### PR TITLE
Added the bounds of the dc_slew_rate_V_per_s parameter of the QDAC

### DIFF
--- a/src/qcodes_contrib_drivers/drivers/QDevil/QDAC2.py
+++ b/src/qcodes_contrib_drivers/drivers/QDevil/QDAC2.py
@@ -1508,7 +1508,8 @@ class QDac2Channel(InstrumentChannel):
             unit='V/s',
             set_cmd='sour{1}:volt:slew {0}'.format('{}', channum),
             get_cmd=f'sour{channum}:volt:slew?',
-            get_parser=float
+            get_parser=float,
+            vals=validators.Numbers(0.01, 2e7)
         )
         self.add_parameter(
             name='read_current_A',

--- a/tests/QDevil/test_sim_qdac2_source_dc.py
+++ b/tests/QDevil/test_sim_qdac2_source_dc.py
@@ -176,3 +176,11 @@ def test_dc_abort(qdac):  # noqa
     qdac.ch02.dc_abort()
     # -----------------------------------------------------------------------
     assert qdac.get_recorded_scpi_commands() == ['sour2:dc:abor']
+
+@pytest.mark.parametrize('u', [0.001, 2e8])
+def test_invalid_dc_slew_rate(u, qdac):  # noqa
+    # -----------------------------------------------------------------------
+    with pytest.raises(ValueError) as error:
+        qdac.ch01.dc_slew_rate_V_per_s(u)
+    # -----------------------------------------------------------------------
+    assert f'{u} is invalid' in repr(error)


### PR DESCRIPTION
The QDAC has a limitation in the bounds of the slew rate (0.01 V/s to 2e7 V/s), this change sets these bounds in the parameter of the QDAC.