### PR TITLE
Fix warning from codecov

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -63,7 +63,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5.4.3
       with:
-        file: ./coverage.xml
         env_vars: OS,PYTHON
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov no longer takes a file argument but
discovers the files to upload from the current directory.