### PR TITLE
Add driver for Weinschel 8331

### DIFF
--- a/docs/examples/Weinschel_8331.ipynb
+++ b/docs/examples/Weinschel_8331.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "089964ca-fdb2-48da-913d-ecf0e5441ceb",
+   "metadata": {},
+   "source": [
+    "# QCoDeS Example with Weinschel 8331 multi-channel stepped attenuator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d814a4f4-d975-4e8a-b28b-facc1ce035a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qcodes_contrib_drivers.drivers.Weinschel.Weinschel_8331 import Weinschel8331"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f725ffc-cb1e-40b9-876d-fced31ebd7dc",
+   "metadata": {},
+   "source": [
+    "Initialize the instrument. In this example, we have four channels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "20aa33e9-5782-4b12-93d9-b1ca3c10031a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to: API Weinschel 8331 (serial:979, firmware:V2.60) in 0.22s\n"
+     ]
+    }
+   ],
+   "source": [
+    "att = Weinschel8331(\n",
+    "    name=\"att\",\n",
+    "    address=\"TCPIP::10.10.200.122::10001::SOCKET\",\n",
+    "    num_channels=4,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0ba39974-4057-4331-bfd1-117145704f22",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "att:\n",
+      "\tparameter   value\n",
+      "--------------------------------------------------------------------------------\n",
+      "IDN          :\t{'vendor': 'API Weinschel', 'model': '8331', 'serial': '979', ...\n",
+      "attenuation1 :\t0 (dB)\n",
+      "attenuation2 :\t0 (dB)\n",
+      "attenuation3 :\t0 (dB)\n",
+      "attenuation4 :\t0 (dB)\n",
+      "timeout      :\t5 (s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "att.print_readable_snapshot(update=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e194d9-be1b-4dbd-9061-b2aa90859be5",
+   "metadata": {},
+   "source": [
+    "Set the attenuation of channel 3 to 12 dB. The attenuation can be set in steps of 2 dB, with a maximum of 62 dB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "48c2e979-65ea-4ae4-bf4e-217b7d31fc22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "att.attenuation3(12)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  },
+  "nbsphinx": {
+   "execute": "never"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/qcodes_contrib_drivers/drivers/Weinschel/Weinschel_8331.py
+++ b/src/qcodes_contrib_drivers/drivers/Weinschel/Weinschel_8331.py
@@ -1,0 +1,53 @@
+from typing import TYPE_CHECKING
+
+from qcodes.validators import Enum
+from qcodes.instrument import VisaInstrument, VisaInstrumentKWArgs
+from qcodes.parameters import Parameter
+
+
+if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
+class Weinschel8331(VisaInstrument):
+    """
+    QCodes driver for Weinschel 8331 stepped attenuator.
+
+    Weinschel is formerly known as Aeroflex/Weinschel
+
+    Very similar to the Weinschel 8320 driver that comes built in with QCodes,
+    but supports multiple channels. We don't know of a way to programmatically
+    query the number of channels, so it must be provided as a parameter to the
+    constructor. The attenuation parameters for each channel are called
+    attenuation1, attenuation2, and so on.
+
+    The default port for a socket connection is 10001.
+    """
+
+    default_terminator = "\r"
+
+    def __init__(
+        self,
+        name: str,
+        address: str,
+        num_channels: int,
+        **kwargs: "Unpack[VisaInstrumentKWArgs]",
+    ):
+        super().__init__(name=name, address=address, **kwargs)
+        for n in range(1, num_channels + 1):
+            setattr(
+                self,
+                f"attenuation{n}",
+                Parameter(
+                    f"attenuation{n}",
+                    unit="dB",
+                    set_cmd=f"ATTN {n} " + "{0:0=2d}",
+                    get_cmd=f"ATTN? {n}",
+                    vals=Enum(*range(0, 62 + 1, 2)),
+                    instrument=self,
+                    get_parser=int,
+                    label=f"Channel {n} attenuation",
+                    docstring=f"Control the attenuation of channel {n}",
+                )
+            )
+
+        self.connect_message()


### PR DESCRIPTION
Hi, here is a driver for the Weinschel 8331 step attenuator. This is very similar to the [qcodes built in driver for the 8320](https://microsoft.github.io/Qcodes/drivers_api/Weinschel.html#qcodes.instrument_drivers.weinschel.Weinschel8320), but it has multiple channels.

I suppose it would also be possible to modify the 8320 driver to pass the number of channels as a parameter (with a default of 1), please let me know if you want me to do that instead. (We would need to be careful with backwards compatibility, here the parameters are called attenuation1, attenuation2, etc, while the current 8320 driver has a single parameter called 'attenuation'.)