### PR TITLE
Fix type checking with QCoDeS 0.59.0

### DIFF
--- a/src/qcodes_contrib_drivers/drivers/Keysight/Keysight_E5080B.py
+++ b/src/qcodes_contrib_drivers/drivers/Keysight/Keysight_E5080B.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import numpy as np
 from qcodes import validators as vals
-from qcodes import VisaInstrument
+from qcodes.instrument import VisaInstrument
 from qcodes.parameters import Parameter, create_on_off_val_mapping
 from qcodes.validators import Enum, Numbers
 

--- a/src/qcodes_contrib_drivers/drivers/M2/M2_Solstis_3.py
+++ b/src/qcodes_contrib_drivers/drivers/M2/M2_Solstis_3.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import random
 import time
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 from qcodes.instrument.ip import IPInstrument
 from qcodes.parameters import create_on_off_val_mapping
@@ -186,11 +186,11 @@ class M2Solstis3(IPInstrument):
         return answer['message']['parameters']
 
     def snapshot_base(
-            self, update: bool | None = False,
+            self, update: bool | Literal['All', 'Only_invalid', 'Never'] | None = False,
             params_to_skip_update: Sequence[str] | None = None
     ) -> dict[Any, Any]:
         snapshot = super().snapshot_base(update, params_to_skip_update)
         snapshot['controller_address'] = self._controller_address
-        if update and 'status' not in (params_to_skip_update or []):
+        if update in (True, 'All') and 'status' not in (params_to_skip_update or []):
             snapshot['status'] = self.get_status()
         return snapshot

--- a/src/qcodes_contrib_drivers/drivers/NanoVNA/H4.py
+++ b/src/qcodes_contrib_drivers/drivers/NanoVNA/H4.py
@@ -8,7 +8,7 @@ A documentation notebook is in the docs/examples/ directory.
 import numpy as np
 from typing import Any, Dict
 
-from qcodes import Instrument
+from qcodes.instrument import Instrument
 from qcodes.parameters import ParameterWithSetpoints
 from qcodes.validators import Arrays, Enum
 

--- a/src/qcodes_contrib_drivers/drivers/QDevil/QDAC1.py
+++ b/src/qcodes_contrib_drivers/drivers/QDevil/QDAC1.py
@@ -7,7 +7,7 @@ import time
 from collections import namedtuple
 from enum import Enum
 from functools import partial
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Sequence, Tuple, Union
 
 import pyvisa
 import pyvisa.constants
@@ -138,11 +138,11 @@ class QDacChannel(InstrumentChannel):
 
     def snapshot_base(
             self,
-            update: Optional[bool] = False,
+            update: bool | Literal['All', 'Only_invalid', 'Never'] | None = False,
             params_to_skip_update: Optional[Sequence[str]] = None
     ) -> Dict[Any, Any]:
         update_currents = self._parent._update_currents and update
-        if update and not self._parent._get_status_performed:
+        if update in (True, 'All') and not self._parent._get_status_performed:
             self._parent._update_cache(update_currents=update_currents)
         # call update_cache rather than getting the status individually for
         # each parameter. This is only done if _get_status_performed is False
@@ -421,11 +421,11 @@ class QDac(VisaInstrument):
 
     def snapshot_base(
             self,
-            update: Optional[bool] = False,
+            update: bool | Literal['All', 'Only_invalid', 'Never'] | None = False,
             params_to_skip_update: Optional[Sequence[str]] = None
     ) -> Dict[Any, Any]:
         update_currents = self._update_currents and update is True
-        if update:
+        if update in (True, 'All'):
             self._update_cache(update_currents=update_currents)
             self._get_status_performed = True
         # call _update_cache rather than getting the status individually for

--- a/src/qcodes_contrib_drivers/drivers/Santec/Santec_TSL.py
+++ b/src/qcodes_contrib_drivers/drivers/Santec/Santec_TSL.py
@@ -3,8 +3,8 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-from qcodes import validators as vals, VisaInstrument
-from qcodes.instrument import InstrumentBaseKWArgs
+from qcodes import validators as vals
+from qcodes.instrument import InstrumentBaseKWArgs, VisaInstrument
 from qcodes.parameters import Parameter, create_on_off_val_mapping
 
 if TYPE_CHECKING:

--- a/src/qcodes_contrib_drivers/drivers/SwabianInstruments/private/time_tagger.py
+++ b/src/qcodes_contrib_drivers/drivers/SwabianInstruments/private/time_tagger.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from collections.abc import Callable, Sequence, Collection
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -285,7 +285,7 @@ class TimeTaggerInstrumentBase(InstrumentBase, metaclass=abc.ABCMeta):
     def api(self):
         pass
 
-    def snapshot_base(self, update: bool | None = False,
+    def snapshot_base(self, update: bool | Literal['All', 'Only_invalid', 'Never'] | None = False,
                       params_to_skip_update: Sequence[str] | None = None) -> dict[Any, Any]:
         key = f'{self.__class__.__qualname__} API configuration'
         try:

--- a/src/qcodes_contrib_drivers/drivers/Windfreak/Windfreak_SynthHD.py
+++ b/src/qcodes_contrib_drivers/drivers/Windfreak/Windfreak_SynthHD.py
@@ -1,4 +1,4 @@
-from qcodes import Instrument, InstrumentChannel
+from qcodes.instrument import Instrument, InstrumentChannel
 import qcodes.parameters
 from qcodes.validators import Numbers, Enum, Ints
 from windfreak import SynthHD

--- a/src/qcodes_contrib_drivers/drivers/WindfreakTechnologies/SynthHD.py
+++ b/src/qcodes_contrib_drivers/drivers/WindfreakTechnologies/SynthHD.py
@@ -1,4 +1,4 @@
-from qcodes import Instrument, InstrumentChannel
+from qcodes.instrument import Instrument, InstrumentChannel
 import qcodes.parameters
 from qcodes.validators import Numbers, Enum, Ints
 from windfreak import SynthHD

--- a/src/qcodes_contrib_drivers/drivers/ZurichInstruments/ZIHDAWG8.py
+++ b/src/qcodes_contrib_drivers/drivers/ZurichInstruments/ZIHDAWG8.py
@@ -5,7 +5,7 @@ import re
 import textwrap
 import time
 from functools import partial
-from typing import Any, List, Tuple, Union, Sequence, Dict, Optional
+from typing import Any, List, Literal, Tuple, Union, Sequence, Dict, Optional
 
 import numpy as np
 import zhinst.utils
@@ -64,7 +64,7 @@ class ZIHDAWG8(Instrument):
         self.warnings_as_errors: List[str] = []
         self._compiler_sleep_time = 0.01
 
-    def snapshot_base(self, update: Optional[bool] = True,
+    def snapshot_base(self, update: bool | Literal['All', 'Only_invalid', 'Never'] | None = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """ Override the base method to ignore 'feature_code' by default."""


### PR DESCRIPTION
* Stop using long deprecated imports 
* Update snapshot_base to match new api. 